### PR TITLE
Make number_mutation more robust to different float formats

### DIFF
--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -39,12 +39,13 @@ def number_mutation(value, **_):
         value = value[1:]
     else:
         base = 10
-
-    if '.' in value:
-        assert base == 10
-        parsed = float(value)
-    else:
+    
+    try:
         parsed = int(value, base=base)
+    except ValueError:
+        # Since it wasn't an int, it must be a float
+        base = 10
+        parsed = float(value)
 
     result = repr(parsed + 1)
     if not result.endswith(suffix):

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -12,6 +12,8 @@ import pytest
         ('1/1', '2*2'),
         # ('1.0', '1.0000000000000002'),  # using numpy features
         ('1.0', '2.0'),
+        ('0.1', '1.1'),
+        ('1e-3', '1.001'),
         ('True', 'False'),
         ('False', 'True'),
         ('"foo"', '"XXfooXX"'),


### PR DESCRIPTION
1. the code would fail with floats using scientific notation, e.g. 1e-3 was what we had in our code, I believe. This is the reason for the try...except
2. Line 47 (the base = 10) was because our floats between 0 and 1, e.g. 0.1, were being set to base 8 by the if statement on line 37