### PR TITLE
Fix coverage_exclude_callback

### DIFF
--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -451,7 +451,8 @@ def coverage_exclude_callback(context, use_coverage, coverage_data):
         measured_lines = coverage_data.lines(os.path.abspath(context.filename))
         if measured_lines is None:
             return True
-        if context.current_line not in measured_lines:
+        current_line = context.current_line_index + 1
+        if current_line not in measured_lines:
             return True
 
     return False


### PR DESCRIPTION
`context.current_line` does not exist, but should be `current_line_index + 1` (coverage.py appears to be 1-based here).


Fixes:

```
% mutmut --use-coverage --runner 'python -m pytest testing/test_collection.py' src/_pytest/nodes.py
Running tests without mutations... Done
Using coverage data from .coverage file
Failed while creating mutations for src/_pytest/nodes.py, for line "from __future__ import absolute_import"
Traceback (most recent call last):
  File "…/Vcs/pytest/.venv/bin/mutmut", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "…/Vcs/mutmut/bin/mutmut", line 5, in <module>
    main()
  File "…/Vcs/pytest/.venv/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "…/Vcs/pytest/.venv/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "…/Vcs/pytest/.venv/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "…/Vcs/pytest/.venv/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "…/Vcs/mutmut/mutmut/__main__.py", line 55, in wrapper
    f(*args, **kwargs)
  File "…/Vcs/mutmut/mutmut/__main__.py", line 235, in main
    add_mutations_by_file(mutations_by_file, filename, _exclude, dict_synonyms)
  File "…/Vcs/mutmut/mutmut/__main__.py", line 443, in add_mutations_by_file
    mutations_by_file[filename] = list_mutations(context)
  File "…/Vcs/mutmut/mutmut/__init__.py", line 381, in list_mutations
    mutate(context)
  File "…/Vcs/mutmut/mutmut/__init__.py", line 287, in mutate
    mutate_list_of_nodes(result, context=context)
  File "…/Vcs/mutmut/mutmut/__init__.py", line 360, in mutate_list_of_nodes
    mutate_node(i, context=context)
  File "…/Vcs/mutmut/mutmut/__init__.py", line 315, in mutate_node
    mutate_list_of_nodes(i, context=context)
  File "…/Vcs/mutmut/mutmut/__init__.py", line 360, in mutate_list_of_nodes
    mutate_node(i, context=context)
  File "…/Vcs/mutmut/mutmut/__init__.py", line 315, in mutate_node
    mutate_list_of_nodes(i, context=context)
  File "…/Vcs/mutmut/mutmut/__init__.py", line 360, in mutate_list_of_nodes
    mutate_node(i, context=context)
  File "…/Vcs/mutmut/mutmut/__init__.py", line 326, in mutate_node
    if context.exclude_line():
  File "…/Vcs/mutmut/mutmut/__init__.py", line 243, in exclude_line
    return self.current_line_index in self.pragma_no_mutate_lines or self.exclude(context=self)
  File "…/Vcs/mutmut/mutmut/__main__.py", line 230, in _exclude
    return coverage_exclude_callback(context=context, use_coverage=use_coverage, coverage_data=coverage_data)
  File "…/Vcs/mutmut/mutmut/__main__.py", line 454, in coverage_exclude_callback
    if context.current_line not in measured_lines:
AttributeError: 'Context' object has no attribute 'current_line'
```
