### PR TITLE
[Experimental] Initial attempt at adding JUnit XML support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,3 +110,17 @@ You can also tell mutmut to just check a single mutant:
 .. code-block:: shell
 
     > mutmut run 3
+
+
+JUnit XML support
+-----------------
+
+In order to better integrate with CI/CD systems, `mutmut` supports the generation of a JUnit XML report (using https://pypi.org/project/junit-xml/).
+This option is available by calling `mutmut junitxml`. In order to define how to deal with suspicious and untested mutants, you can use `mutmut junitxml --suspicious-policy=ignore --untested-policy=ignore`.
+The possible values for these policies are:
+- `ignore`: Do not include the results on the report at all
+- `skipped`: Include the mutant on the report as "skipped"
+- `error`: Include the mutant on the report as "error"
+- `failure`: Include the mutant on the report as "failure"
+
+If a failed mutant is included in the report, then the unified diff of the mutant will also be included for debugging purposes.

--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,7 @@ JUnit XML support
 In order to better integrate with CI/CD systems, `mutmut` supports the generation of a JUnit XML report (using https://pypi.org/project/junit-xml/).
 This option is available by calling `mutmut junitxml`. In order to define how to deal with suspicious and untested mutants, you can use `mutmut junitxml --suspicious-policy=ignore --untested-policy=ignore`.
 The possible values for these policies are:
+
 - `ignore`: Do not include the results on the report at all
 - `skipped`: Include the mutant on the report as "skipped"
 - `error`: Include the mutant on the report as "error"

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -164,12 +164,14 @@ DEFAULT_TESTS_DIR = 'tests/:test/'
 @click.option('--dict-synonyms')
 @click.option('--cache-only', is_flag=True, default=False)
 @click.option('--version', is_flag=True, default=False)
+@click.option('--suspicious-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
+@click.option('--untested-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
 @config_from_setup_cfg(
     dict_synonyms='',
     runner='python -m pytest -x',
     tests_dir=DEFAULT_TESTS_DIR,
 )
-def main(command, argument, paths_to_mutate, backup, runner, tests_dir, s, use_coverage, dict_synonyms, cache_only, version):
+def main(command, argument, paths_to_mutate, backup, runner, tests_dir, s, use_coverage, dict_synonyms, cache_only, version, suspicious_policy, untested_policy):
     """
 commands:\n
     run [mutation id]\n
@@ -214,7 +216,7 @@ commands:\n
         return
 
     if command == 'junitxml':
-        print_result_cache_junitxml(dict_synonyms)
+        print_result_cache_junitxml(dict_synonyms, suspicious_policy, untested_policy)
         return
 
     if command == 'apply':

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -19,7 +19,8 @@ import click
 from glob2 import glob
 
 from mutmut.cache import register_mutants, update_mutant_status, print_result_cache, cached_mutation_status, \
-    mutation_id_from_pk, filename_and_mutation_id_from_pk, cached_test_time, set_cached_test_time, update_line_numbers
+    mutation_id_from_pk, filename_and_mutation_id_from_pk, cached_test_time, set_cached_test_time, update_line_numbers, \
+    print_result_cache_junitxml
 from . import mutate_file, Context, list_mutations, __version__, BAD_TIMEOUT, OK_SUSPICIOUS, BAD_SURVIVED, OK_KILLED, UNTESTED, mutate
 from .cache import hash_of_tests
 
@@ -184,7 +185,7 @@ commands:\n
         print("mutmut version %s" % __version__)
         return
 
-    valid_commands = ['run', 'results', 'apply', 'show']
+    valid_commands = ['run', 'results', 'apply', 'show', 'junitxml']
     if command not in valid_commands:
         print('%s is not a valid command, must be one of %s' % (command, ', '.join(valid_commands)))
         return
@@ -225,6 +226,10 @@ commands:\n
 
     if command == 'results':
         print_result_cache()
+        return
+
+    if command == 'junitxml':
+        print_result_cache_junitxml()
         return
 
     if command == 'apply':

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -20,7 +20,7 @@ from glob2 import glob
 
 from mutmut.cache import register_mutants, update_mutant_status, print_result_cache, cached_mutation_status, \
     mutation_id_from_pk, filename_and_mutation_id_from_pk, cached_test_time, set_cached_test_time, update_line_numbers, \
-    print_result_cache_junitxml
+    print_result_cache_junitxml, get_unified_diff
 from . import mutate_file, Context, list_mutations, __version__, BAD_TIMEOUT, OK_SUSPICIOUS, BAD_SURVIVED, OK_KILLED, UNTESTED, mutate
 from .cache import hash_of_tests
 
@@ -201,22 +201,7 @@ commands:\n
             print_result_cache()
             return
 
-        filename, mutation_id = filename_and_mutation_id_from_pk(argument)
-        with open(filename) as f:
-            source = f.read()
-        context = Context(
-            source=source,
-            filename=filename,
-            mutation_id=mutation_id,
-            dict_synonyms=dict_synonyms,
-        )
-        mutated_source, number_of_mutations_performed = mutate(context)
-        if not number_of_mutations_performed:
-            print('No mutation performed')
-            return
-
-        for line in unified_diff(source.split('\n'), mutated_source.split('\n'), fromfile=filename, tofile=filename, lineterm=''):
-            print(line)
+        print(get_unified_diff(argument, dict_synonyms))
 
         return
 
@@ -229,7 +214,7 @@ commands:\n
         return
 
     if command == 'junitxml':
-        print_result_cache_junitxml()
+        print_result_cache_junitxml(dict_synonyms)
         return
 
     if command == 'apply':

--- a/mutmut/cache.py
+++ b/mutmut/cache.py
@@ -169,7 +169,7 @@ def print_result_cache_junitxml(dict_synonyms):
             # TODO: Use the unified diff output instead of the plain line
             tc = TestCase("Mutant #{}".format(mutant.id), file=filename, line=mutant.line.line_number, stdout=mutant.line.line)
             if mutant.status == BAD_SURVIVED:
-                tc.add_failure_info(message=mutant.status)
+                tc.add_failure_info(message=mutant.status, output=get_unified_diff(mutant.id, dict_synonyms))
             if mutant.status == BAD_TIMEOUT:
                 tc.add_error_info(message=mutant.status, error_type="timeout", output=get_unified_diff(mutant.id, dict_synonyms))
             if mutant.status == OK_SUSPICIOUS:

--- a/mutmut/cache.py
+++ b/mutmut/cache.py
@@ -166,7 +166,6 @@ def print_result_cache_junitxml(dict_synonyms, suspicious_policy, untested_polic
     l = list(select(x for x in Mutant))
     for filename, mutants in groupby(l, key=lambda x: x.line.sourcefile.filename):
         for mutant in mutants:
-            # TODO: Use the unified diff output instead of the plain line
             tc = TestCase("Mutant #{}".format(mutant.id), file=filename, line=mutant.line.line_number, stdout=mutant.line.line)
             if mutant.status == BAD_SURVIVED:
                 tc.add_failure_info(message=mutant.status, output=get_unified_diff(mutant.id, dict_synonyms))
@@ -182,7 +181,6 @@ def print_result_cache_junitxml(dict_synonyms, suspicious_policy, untested_polic
                     func(message=mutant.status, output=get_unified_diff(mutant.id, dict_synonyms))
 
             test_cases.append(tc)
-            # print(filename, mutant.to_dict())
 
     ts = TestSuite("mutmut", test_cases)
     print(TestSuite.to_xml_string([ts]))

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ parso
 tri.declarative
 click
 pony
+junit-xml==1.8


### PR DESCRIPTION
Related to #49. Most CI tools include some support for interpreting JUnit XML output, extracting information about total executed tests vs. passed, capturing stdout/stderr from test execution, etc. This is an attempt at implementing some very rudimentary support for JUnit XML in mutmut.

In order to get the report in this new format, simply run `mutmut junitxml` (similar to running `mutmut results`)

**Notes for discussion:**
- [ ]  This could be exposed as a modified/parameter to the `results` command, instead of a new command (it's just a different way of reporting the results).
- [x]  What to show on the `stdout` and `stderr` attributes. Right now I'm simply adding `Mutant.line.line`, but ideally we want to show the diff of the mutant. It seems the code for generating the diff is on the `__main__.py` file, so maybe that can be refactored and reused there?
- [x]  What is a `failure` vs. `error` vs `skipped`? I'm using `failure` for surviving mutants, `error` for timeouts, and `skipped` for both untested and suspicious. A flag could be added to determine if suspicious mutants should be skipped or considered failures/errors