### PR TITLE
Fix `popen_streaming_output` killing wrong process on Ubuntu

### DIFF
--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -7,7 +7,6 @@ import os
 import sys
 import signal
 from datetime import datetime
-from difflib import unified_diff
 from functools import wraps
 from io import open
 from os.path import isdir, exists
@@ -20,9 +19,9 @@ import click
 from glob2 import glob
 
 from mutmut.cache import register_mutants, update_mutant_status, print_result_cache, cached_mutation_status, \
-    mutation_id_from_pk, filename_and_mutation_id_from_pk, cached_test_time, set_cached_test_time, update_line_numbers, \
+    filename_and_mutation_id_from_pk, cached_test_time, set_cached_test_time, update_line_numbers, \
     print_result_cache_junitxml, get_unified_diff
-from . import mutate_file, Context, list_mutations, __version__, BAD_TIMEOUT, OK_SUSPICIOUS, BAD_SURVIVED, OK_KILLED, UNTESTED, mutate
+from . import mutate_file, Context, list_mutations, __version__, BAD_TIMEOUT, OK_SUSPICIOUS, BAD_SURVIVED, OK_KILLED, UNTESTED
 from .cache import hash_of_tests
 
 spinner = itertools.cycle('⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏')


### PR DESCRIPTION
Explanation is in the [issue thread](https://github.com/boxed/mutmut/issues/37#issuecomment-449871683).
Also removed unused imports because flake8 was yelling at me.

#37 