### PR TITLE
Fix python2 support for `popen_straming_output`, improve tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ examples/db.sqlite3
 venv
 table.css.map
 .idea
+.vscode
 .cache
 .DS_Store
 .pytest_cache

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,3 @@
 pytest>=2.8.7
 pytest-cov
+mock == 2.0.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,3 @@
 pytest>=2.8.7
 pytest-cov
-mock == 2.0.0
+mock==2.0.0


### PR DESCRIPTION
While resolving prevous `popen_straming_output` bug I realised that there is missing a test case for streaming capabilities, after I added test I realised that function would swallow the last (few) lines if they are printed at the same time. Basically only one line is read and if few lines came at the same time `poll()` would set the `returncode` regardless and while loop would break.
I tried:
```
for line in stdout:
     callback(line)
```
And for some reason that doesn't stream properly (waits till the exit and dumps everything) on python2 even though it seems to be similar code:

https://github.com/python/cpython/blob/112e4afd582515fcdcc0cde5012a4866e5cfda12/Lib/_pyio.py#L502-L506

If someone has any idea, please let me know. Should have something to do with buffers.
For now I settled with uglier solution but it works, tests pass.

Moved from `shell=True` to `shlex` since there is no need to have parent shell process, makes killing the process easier.
Also support for python2 was lacking, that should be fixed now.

Removed `pytestmark` from module level since some of the tests work on python2 and I see no reason why all of those should not run, especially those related to `popen_streaming_output`.