### PR TITLE
Bugfix/fixing coverage usage

### DIFF
--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -530,7 +530,9 @@ def read_coverage_data(use_coverage):
         print('Using coverage data from .coverage file')
         # noinspection PyPackageRequirements,PyUnresolvedReferences
         from coverage import Coverage
-        return Coverage('.coverage').get_data()
+        cov = Coverage('.coverage')
+        cov.load()
+        return cov.get_data()
     else:
         return None
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -315,7 +315,7 @@ def test_use_coverage(capsys, filesystem):
         f.write(test_file_contents.replace('assert foo(2, 2) is False\n', ''))
 
     # first validate that mutmut without coverage detects a surviving mutant
-    result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py'], catch_exceptions=False)
+    result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=5.0"], catch_exceptions=False)
     print(repr(result.output))
     assert result.exit_code == 2
 
@@ -332,7 +332,7 @@ def test_use_coverage(capsys, filesystem):
     pytest.main(["--cov=.", "foo.py"])
     assert os.path.isfile('.coverage')
 
-    result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--use-coverage"], catch_exceptions=False)
+    result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=5.0", "--use-coverage"], catch_exceptions=False)
     print(repr(result.output))
     assert result.exit_code == 0
     if EXPECTED_MUTANTS == 8:  # python3

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -264,7 +264,7 @@ def test_full_run_all_suspicious_mutant(filesystem):
     result = CliRunner().invoke(climain, ['results'], catch_exceptions=False)
     print(repr(result.output))
     assert result.exit_code == 0
-    if EXPECTED_MUTANTS == 8:
+    if EXPECTED_MUTANTS == 8:  # python3
         assert result.output.strip() == u"""
 To apply a mutant on disk:
     mutmut apply <id>
@@ -279,7 +279,7 @@ Suspicious 🤔 (8)
 
 1, 2, 3, 4, 5, 6, 7, 8
 """.strip()
-    else:
+    else:  # python2
         assert result.output.strip() == u"""
 To apply a mutant on disk:
     mutmut apply <id>
@@ -308,3 +308,34 @@ def test_full_run_all_suspicious_mutant_junit(filesystem):
     assert int(root.attrib['failures']) == 0
     assert int(root.attrib['errors']) == 0
     assert int(root.attrib['disabled']) == 0
+
+
+def test_use_coverage(capsys, filesystem):
+    with open(os.path.join(str(filesystem), "tests", "test_foo.py"), 'w') as f:
+        f.write(test_file_contents.replace('assert foo(2, 2) is False\n', ''))
+
+    # first validate that mutmut without coverage detects a surviving mutant
+    result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py'], catch_exceptions=False)
+    print(repr(result.output))
+    assert result.exit_code == 2
+
+    result = CliRunner().invoke(climain, ['junitxml'], catch_exceptions=False)
+    print(repr(result.output))
+    assert result.exit_code == 0
+    root = ET.fromstring(result.output.strip())
+    assert int(root.attrib['tests']) == EXPECTED_MUTANTS
+    assert int(root.attrib['failures']) == 1
+    assert int(root.attrib['errors']) == 0
+    assert int(root.attrib['disabled']) == 0
+
+    # generate a `.coverage` file by invoking pytest
+    pytest.main(["--cov=.", "foo.py"])
+    assert os.path.isfile('.coverage')
+
+    result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--use-coverage"], catch_exceptions=False)
+    print(repr(result.output))
+    assert result.exit_code == 0
+    if EXPECTED_MUTANTS == 8:  # python3
+        assert '7/7  🎉 7  ⏰ 0  🤔 0  🙁 0' in repr(result.output)
+    else:  # python2
+        assert '8/8  \\U0001f389 8  \\u23f0 0  \\U0001f914 0  \\U0001f641 0' in repr(result.output)


### PR DESCRIPTION
The loading of `Coverage()` is incorrect leading to an emtpy `Coverage()` object being return.

This PR resolves this issue along with adding tests to properly validate the functionality of the `--use-coverage` flag.