### PR TITLE
Switch setup.py to 'console_scripts' from 'scripts'

### DIFF
--- a/bin/mutmut
+++ b/bin/mutmut
@@ -1,5 +1,0 @@
-#!/usr/bin/env python
-
-if __name__ == '__main__':
-    from mutmut.__main__ import climain
-    climain()

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+﻿#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import os
@@ -130,7 +130,8 @@ setup(
     entry_points={
         'pytest11': [
             'mutmut = mutmut.pytestplugin',
-        ]
-    } if running_inside_tests else {},
-    scripts=['bin/mutmut'],
+        ],
+    } if running_inside_tests else {
+        'console_scripts': ["mutmut = mutmut.__main__:climain"],
+    },
 )


### PR DESCRIPTION
Closes #115.

This configuration of `setup.py` results in a `mutmut` CLI script that works for me both on Windows 10 and on Debian stretch.