### PR TITLE
Use sys.executable as default python executable

### DIFF
--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -193,7 +193,7 @@ DEFAULT_TESTS_DIR = 'tests/:test/'
 @click.option('--post-mutation')
 @config_from_setup_cfg(
     dict_synonyms='',
-    runner='python -m pytest -x',
+    runner='"' + sys.executable + '" -m pytest -x',
     tests_dir=DEFAULT_TESTS_DIR,
     pre_mutation=None,
     post_mutation=None,


### PR DESCRIPTION
It's more likely to be the correct Python executable in case where someone specified the executable when running mutmut.
On Windows 7, there is also a weird thing with the way the search is done which makes just "python" not work with venv...