### PR TITLE
Check for non existent filepaths when using coverage data

### DIFF
--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -337,6 +337,7 @@ Legend for output:
         covered_lines_by_filename = {}
         if use_coverage:
             coverage_data = read_coverage_data()
+            check_coverage_data_filepaths(coverage_data)
         else:
             assert use_patch_file
             covered_lines_by_filename = read_patch_data(use_patch_file)
@@ -393,6 +394,12 @@ Legend for output:
         return compute_exit_code(progress)
     finally:
         print()  # make sure we end the output with a newline
+
+
+def check_coverage_data_filepaths(coverage_data):
+    for filepath in coverage_data._lines:
+        if not os.path.exists(filepath):
+            raise ValueError('Filepaths in .coverage not recognized, try recreating the .coverage file manually.')
 
 
 def get_mutations_by_file_from_cache(mutation_pk):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -342,7 +342,7 @@ def test_use_coverage(capsys, filesystem):
         content = f.read()
 
     # the new path is linux-based, but it just needs to be wrong
-    new_content = re.sub(r'\"[\w/\-\\]*.py\"', '"/test_path/foo.py"', content)
+    new_content = re.sub(r'\"[\w\W][^{]*foo.py\"', '"/test_path/foo.py"', content)
 
     with open('.coverage', 'w') as f:
         f.write(new_content)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -340,7 +340,9 @@ def test_use_coverage(capsys, filesystem):
     # replace the .coverage file content with a non existent path to check if an exception is thrown
     with open('.coverage', 'r') as f:
         content = f.read()
-    new_content = re.sub(r'\"[\w/\-]*.py\"', '"/test_path/foo.py"', content)
+
+    # the new path is linux-based, but it just needs to be wrong
+    new_content = re.sub(r'\"[\w/\-\\]*.py\"', '"/test_path/foo.py"', content)
 
     with open('.coverage', 'w') as f:
         f.write(new_content)


### PR DESCRIPTION
fixed issue #76 

Added a simple check after loading the .coverage data: if a path doesn't exist raise an exception, ensuring that the .coverage file is usable.

Especially needed when generating coverage with PyCharm

