### PR TITLE
Add coverage 5 support

### DIFF
--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -456,7 +456,7 @@ def should_exclude(context, config):
         covered_lines = config.covered_lines_by_filename[context.filename]
     except KeyError:
         if config.coverage_data is not None:
-            covered_lines = config.coverage_data.lines(os.path.abspath(context.filename))
+            covered_lines = config.coverage_data.get(os.path.abspath(context.filename))
             config.covered_lines_by_filename[context.filename] = covered_lines
         else:
             covered_lines = None
@@ -688,7 +688,6 @@ def mutate_file(backup, context):
 
 
 def queue_mutants(*, progress, config, mutants_queue, mutations_by_file):
-    from mutmut.cache import update_line_numbers
     from mutmut.cache import get_cached_mutation_statuses
 
     try:
@@ -938,7 +937,7 @@ class Progress(object):
 
 
 def check_coverage_data_filepaths(coverage_data):
-    for filepath in coverage_data._lines:
+    for filepath in coverage_data:
         if not os.path.exists(filepath):
             raise ValueError('Filepaths in .coverage not recognized, try recreating the .coverage file manually.')
 
@@ -1160,7 +1159,8 @@ def read_coverage_data():
         raise ImportError('The --use-coverage feature requires the coverage library. Run "pip install --force-reinstall mutmut[coverage]"') from e
     cov = Coverage('.coverage')
     cov.load()
-    return cov.get_data()
+    data = cov.get_data()
+    return {filepath: data.lines(filepath) for filepath in data.measured_files()}
 
 
 def read_patch_data(patch_file_path):

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,15 @@ addopts = --junitxml=testreport.xml --strict -r fEsxXw
 [flake8]
 ignore = E501,E721
 
+[coverage:run]
+source = .
+omit =
+    .tox/*
+    venv/*
+    /private/*
+    /tmp/*
+    setup.py
+
 [coverage:report]
 exclude_lines =
     # Have to re-enable the standard pragma

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import re
 import subprocess
 import sys
 import xml.etree.ElementTree as ET
@@ -155,7 +154,7 @@ def test_compute_return_code():
 
 
 def test_read_coverage_data(filesystem):
-    assert isinstance(read_coverage_data(), CoverageData)
+    assert read_coverage_data() == {}
 
 
 @pytest.mark.parametrize(
@@ -366,8 +365,7 @@ def test_full_run_all_suspicious_mutant_junit(filesystem):
     assert int(root.attrib['disabled']) == 0
 
 
-@pytest.mark.skip("TODO: fix support for coverage 5")
-def test_use_coverage(capsys, filesystem):
+def test_use_coverage(filesystem):
     with open(os.path.join(str(filesystem), "tests", "test_foo.py"), 'w') as f:
         f.write(test_file_contents.replace('assert foo(2, 2) is False\n', ''))
 
@@ -394,16 +392,8 @@ def test_use_coverage(capsys, filesystem):
     assert result.exit_code == 0
     assert '13/13  🎉 13  ⏰ 0  🤔 0  🙁 0' in repr(result.output)
 
-    # replace the .coverage file content with a non existent path to check if an exception is thrown
-    with open('.coverage', 'r') as f:
-        content = f.read()
-
-    # the new path is linux-based, but it just needs to be wrong
-    new_content = re.sub(r'\"[\w\W][^{]*foo.py\"', '"/test_path/foo.py"', content)
-
-    with open('.coverage', 'w') as f:
-        f.write(new_content)
-
+    # remove existent path to check if an exception is thrown
+    os.unlink(os.path.join(str(filesystem), 'foo.py'))
     with pytest.raises(ValueError,
                        match=r'^Filepaths in .coverage not recognized, try recreating the .coverage file manually.$'):
         CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0", "--use-coverage"],

--- a/tox.ini
+++ b/tox.ini
@@ -13,9 +13,7 @@ deps =
 basepython = python3.7
 usedevelop = True
 commands =
-    {envpython} -m pytest --cov {posargs}
-    {envpython} -m coverage report -m
-    {envpython} -m coverage html
+    {envpython} -m pytest --cov --cov-config setup.cfg --cov-report term-missing --cov-report html {posargs}
 deps =
     -rrequirements.txt
     -rtest_requirements.txt


### PR DESCRIPTION
Fixes #166.

The `coverage.sqldata.CoverageData` can't be pickled anymore, so the coverage data serialized to a `dict` before sending it to the queue mutants thread.

Also simplified `test_use_coverage` since removing `foo.py` is enough to raise an "Filepaths in .coverage not recognized ..." exception.


---

I've tested `mutmut run --use-coverage` with `pytest` and it works on macOS and Linux fine. With `hammett` it doesn't work on macOS (see the traceback below), but works on Linux. It might be out of scope, let me know your opinion.

<details>

<summary>Traceback.</summary>

```python
  File "/Users/albert/Projects/mutmut/mutmut/__main__.py", line 307, in main
    run_mutation_tests(config=config, progress=progress, mutations_by_file=mutations_by_file)
  File "/Users/albert/Projects/mutmut/mutmut/__init__.py", line 1146, in run_mutation_tests
    update_mutant_status(file_to_mutate=filename, mutation_id=mutation_id, status=status, tests_hash=config.hash_of_tests)
  File "/Users/albert/Projects/mutmut/mutmut/cache.py", line 88, in wrapper
    return f(*args, **kwargs)
  File "<string>", line 2, in update_mutant_status
  File "/Users/albert/Projects/mutmut/venv/lib/python3.7/site-packages/pony/orm/core.py", line 547, in new_func
    reraise(exc_type, exc, tb)
  File "/Users/albert/Projects/mutmut/venv/lib/python3.7/site-packages/pony/utils/utils.py", line 95, in reraise
    try: raise exc.with_traceback(tb)
  File "/Users/albert/Projects/mutmut/venv/lib/python3.7/site-packages/pony/orm/core.py", line 529, in new_func
    commit()
  File "/Users/albert/Projects/mutmut/venv/lib/python3.7/site-packages/pony/orm/core.py", line 393, in commit
    transact_reraise(CommitException, exceptions)
  File "/Users/albert/Projects/mutmut/venv/lib/python3.7/site-packages/pony/orm/core.py", line 363, in transact_reraise
    reraise(exc_class, new_exc, tb)
  File "/Users/albert/Projects/mutmut/venv/lib/python3.7/site-packages/pony/utils/utils.py", line 95, in reraise
    try: raise exc.with_traceback(tb)
  File "/Users/albert/Projects/mutmut/venv/lib/python3.7/site-packages/pony/orm/core.py", line 387, in commit
    primary_cache.commit()
  File "/Users/albert/Projects/mutmut/venv/lib/python3.7/site-packages/pony/orm/core.py", line 1825, in commit
    cache.database.provider.commit(cache.connection, cache)
  File "/Users/albert/Projects/mutmut/venv/lib/python3.7/site-packages/pony/orm/dbproviders/sqlite.py", line 385, in commit
    DBAPIProvider.commit(provider, connection, cache)
  File "<string>", line 2, in commit
  File "/Users/albert/Projects/mutmut/venv/lib/python3.7/site-packages/pony/orm/dbapiprovider.py", line 72, in wrap_dbapi_exceptions
    raise OperationalError(e)
pony.orm.core.CommitException: OperationalError: database is locked
```

</details>