### PR TITLE
Fixed the total mutants and killed column in html report

### DIFF
--- a/mutmut/cache.py
+++ b/mutmut/cache.py
@@ -283,8 +283,8 @@ def create_html_report(dict_synonyms):
                 index_file.write('<tr><td><a href="%s.html">%s</a></td><td>%s</td><td>%s</td><td>%.2f</td><td>%s</td>' % (
                     filename,
                     filename,
-                    killed,
                     len(mutants),
+                    killed,
                     (killed / len(mutants) * 100),
                     len(mutants_by_status[BAD_SURVIVED]),
                 ))


### PR DESCRIPTION
The total number of mutants column and the number killed column should be switched if you look at the table headers.