### PR TITLE
Refactored the Code and improved the Code Quality and Performance

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,10 @@
+version = 1
+
+test_patterns = ["*/test/**"]
+
+[[analyzers]]
+name = "python"
+enabled = true
+
+  [analyzers.meta]
+  runtime_version = "3.x.x"

--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -259,8 +259,7 @@ def lambda_mutation(children, **_):
 
     if len(post) == 1 and getattr(post[0], 'value', None) == 'None':
         return pre + [op] + [Number(value=' 0', start_pos=post[0].start_pos)]
-    else:
-        return pre + [op] + [Keyword(value=' None', start_pos=post[0].start_pos)]
+    return pre + [op] + [Keyword(value=' None', start_pos=post[0].start_pos)]
 
 
 NEWLINE = {'formatting': [], 'indent': '', 'type': 'endl', 'value': ''}
@@ -786,8 +785,7 @@ def run_mutation(context: Context, callback) -> str:
 
         if survived:
             return BAD_SURVIVED
-        else:
-            return OK_KILLED
+        return OK_KILLED
     except SkipException:
         return SKIPPED
 
@@ -891,17 +889,17 @@ def guess_paths_to_mutate():
     this_dir = os.getcwd().split(os.sep)[-1]
     if isdir('lib'):
         return 'lib'
-    elif isdir('src'):
+    if isdir('src'):
         return 'src'
-    elif isdir(this_dir):
+    if isdir(this_dir):
         return this_dir
-    elif isdir(this_dir.replace('-', '_')):
+    if isdir(this_dir.replace('-', '_')):
         return this_dir.replace('-', '_')
-    elif isdir(this_dir.replace(' ', '_')):
+    if isdir(this_dir.replace(' ', '_')):
         return this_dir.replace(' ', '_')
-    elif isdir(this_dir.replace('-', '')):
+    if isdir(this_dir.replace('-', '')):
         return this_dir.replace('-', '')
-    elif isdir(this_dir.replace(' ', '')):
+    if isdir(this_dir.replace(' ', '')):
         return this_dir.replace(' ', '')
     raise FileNotFoundError(
         'Could not figure out where the code to mutate is. '

--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -1140,7 +1140,7 @@ def run_mutation_tests(config, progress, mutations_by_file):
             t.join()
             break
 
-        elif command == 'cycle':
+        if command == 'cycle':
             t = create_worker()
 
         elif command == 'progress':

--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -41,7 +41,7 @@ except ImportError:
     mutmut_config = None
 
 
-class RelativeMutationID(object):
+class RelativeMutationID():
     def __init__(self, line, index, line_number, filename=None):
         self.line = line
         self.index = index
@@ -65,7 +65,7 @@ class InvalidASTPatternException(Exception):
     pass
 
 
-class ASTPattern(object):
+class ASTPattern():
     def __init__(self, source, **definitions):
         if definitions is None:
             definitions = {}
@@ -474,7 +474,7 @@ def should_exclude(context, config):
     return False
 
 
-class Context(object):
+class Context():
     def __init__(self, source=None, mutation_id=ALL, dict_synonyms=None, filename=None, config=None, index=0):
         self.index = index
         self.remove_newline_at_end = False
@@ -805,7 +805,7 @@ def run_mutation(context: Context, callback) -> str:
                 callback(result)
 
 
-class Config(object):
+class Config():
     def __init__(self, swallow_output, test_command, covered_lines_by_filename,
                  baseline_time_elapsed, test_time_multiplier, test_time_base,
                  backup, dict_synonyms, total, using_testmon, cache_only,
@@ -914,7 +914,7 @@ def guess_paths_to_mutate():
         'or by adding "paths_to_mutate=code_dir" in setup.cfg to the [mutmut] section.')
 
 
-class Progress(object):
+class Progress():
     def __init__(self, total):
         self.total = total
         self.progress = 0

--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -97,7 +97,8 @@ class ASTPattern(object):
                 for match in re.finditer(r'\^(?P<value>[^\^]*)', node.value):
                     name = match.groupdict()['value'].strip()
                     d = definitions.get(name, {})
-                    assert set(d.keys()) | {'of_type', 'marker_type'} == {'of_type', 'marker_type'}
+                    if set(d.keys()) | {'of_type', 'marker_type'} != {'of_type', 'marker_type'}:
+                        raise AssertionError
                     self.markers.append(dict(
                         node=get_leaf(line - 1, column + match.start(), of_type=d.get('of_type')),
                         marker_type=d.get('marker_type'),
@@ -251,7 +252,8 @@ def partition_node_list(nodes, value):
         if hasattr(n, 'value') and n.value == value:
             return nodes[:i], n, nodes[i + 1:]
 
-    assert False, "didn't find node to split on"
+    if not False:
+        raise AssertionError("didn't find node to split on")
 
 
 def lambda_mutation(children, **_):
@@ -398,7 +400,8 @@ def expression_mutation(children, **_):
 
 
 def decorator_mutation(children, **_):
-    assert children[-1].type == 'newline'
+    if children[-1].type != 'newline':
+        raise AssertionError
     return children[-1:]
 
 
@@ -479,7 +482,8 @@ class Context(object):
         self._set_source(source)
         self.mutation_id = mutation_id
         self.performed_mutation_ids = []
-        assert isinstance(mutation_id, RelativeMutationID)
+        if not isinstance(mutation_id, RelativeMutationID):
+            raise AssertionError
         self.current_line_index = 0
         self.filename = filename
         self.stack = []
@@ -551,7 +555,8 @@ def mutate(context):
     mutate_list_of_nodes(result, context=context)
     mutated_source = result.get_code().replace(' not not ', ' ')
     if context.remove_newline_at_end:
-        assert mutated_source[-1] == '\n'
+        if mutated_source[-1] != '\n':
+            raise AssertionError
         mutated_source = mutated_source[:-1]
 
     # If we said we mutated the code, check that it has actually changed
@@ -624,7 +629,8 @@ def mutate_node(node, context):
             # adverse effects on subsequent mutations, this ensures the last
             # mutation applied is the original/default/legacy mutmut mutation
             for new in reversed(new_list):
-                assert not callable(new)
+                if callable(new):
+                    raise AssertionError
                 if new is not None and new != old:
                     if hasattr(mutmut_config, 'pre_mutation_ast'):
                         mutmut_config.pre_mutation_ast(context=context)
@@ -666,7 +672,8 @@ def list_mutations(context):
     """
     :type context: Context
     """
-    assert context.mutation_id == ALL
+    if context.mutation_id != ALL:
+        raise AssertionError
     mutate(context)
     return context.performed_mutation_ids
 
@@ -1047,7 +1054,8 @@ def hammett_tests_pass(config, callback):
         nonlocal timed_out
         timed_out = True
 
-    assert current_thread() is main_thread()
+    if current_thread() is not main_thread():
+        raise AssertionError
     timer = Timer(config.baseline_time_elapsed * 10, timeout)
     timer.daemon = True
     timer.start()
@@ -1142,7 +1150,8 @@ def run_mutation_tests(config, progress, mutations_by_file):
                 progress.print()
 
         else:
-            assert command == 'status'
+            if command != 'status':
+                raise AssertionError
 
             progress.register(status)
 

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -271,7 +271,8 @@ Legend for output:
             coverage_data = read_coverage_data()
             check_coverage_data_filepaths(coverage_data)
         else:
-            assert use_patch_file
+            if not use_patch_file:
+                raise AssertionError
             covered_lines_by_filename = read_patch_data(use_patch_file)
 
     if command != 'run':

--- a/mutmut/cache.py
+++ b/mutmut/cache.py
@@ -362,7 +362,8 @@ def update_line_numbers(filename):
         if command == 'equal':
             if a_index != b_index:
                 cached_obj = cached_line_objects[a_index]
-                assert cached_obj.line == existing_lines[b_index]
+                if cached_obj.line != existing_lines[b_index]:
+                    raise AssertionError
                 cached_obj.line_number = b_index
 
         elif command == 'delete':
@@ -416,7 +417,8 @@ def update_mutant_status(file_to_mutate, mutation_id, status, tests_hash):
 @db_session
 def get_cached_mutation_statuses(filename, mutations, hash_of_tests):
     sourcefile = SourceFile.get(filename=filename)
-    assert sourcefile
+    if not sourcefile:
+        raise AssertionError
 
     line_obj_by_line = {}
 
@@ -426,7 +428,8 @@ def get_cached_mutation_statuses(filename, mutations, hash_of_tests):
         if mutation_id.line not in line_obj_by_line:
             line_obj_by_line[mutation_id.line] = Line.get(sourcefile=sourcefile, line=mutation_id.line, line_number=mutation_id.line_number)
         line = line_obj_by_line[mutation_id.line]
-        assert line
+        if not line:
+            raise AssertionError
         mutant = Mutant.get(line=line, index=mutation_id.index)
         if mutant is None:
             mutant = get_or_create(Mutant, line=line, index=mutation_id.index, defaults=dict(status=UNTESTED))
@@ -451,9 +454,11 @@ def get_cached_mutation_statuses(filename, mutations, hash_of_tests):
 @db_session
 def cached_mutation_status(filename, mutation_id, hash_of_tests):
     sourcefile = SourceFile.get(filename=filename)
-    assert sourcefile
+    if not sourcefile:
+        raise AssertionError
     line = Line.get(sourcefile=sourcefile, line=mutation_id.line, line_number=mutation_id.line_number)
-    assert line
+    if not line:
+        raise AssertionError
     mutant = Mutant.get(line=line, index=mutation_id.index)
     if mutant is None:
         mutant = get_or_create(Mutant, line=line, index=mutation_id.index, defaults=dict(status=UNTESTED))

--- a/mutmut/cache.py
+++ b/mutmut/cache.py
@@ -326,8 +326,7 @@ def get_or_create(model, defaults=None, **params):
             if k not in params:
                 params[k] = v
         return model(**params)
-    else:
-        return obj
+    return obj
 
 
 def sequence_ops(a, b):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -13,7 +13,7 @@ def test_sequence_ops():
     ]
     b = a[:]
 
-    assert list(sequence_ops(a, b)) == [
+    if list(sequence_ops(a, b)) != [
         ('equal', 'a', 0, 'a', 0),
         ('equal', 'b', 1, 'b', 1),
         ('equal', 'c', 2, 'c', 2),
@@ -21,14 +21,15 @@ def test_sequence_ops():
         ('equal', 'e', 4, 'e', 4),
         ('equal', 'f', 5, 'f', 5),
         ('equal', 'g', 6, 'g', 6),
-    ]
+    ]:
+        raise AssertionError
 
     # now modify
     b[1] = 'replaced'
     b.insert(3, 'inserted')
     del b[-1]
 
-    assert list(sequence_ops(a, b)) == [
+    if list(sequence_ops(a, b)) != [
         ('equal', 'a', 0, 'a', 0),
         ('replace', 'b', 1, 'replaced', 1),
         ('equal', 'c', 2, 'c', 2),
@@ -37,4 +38,5 @@ def test_sequence_ops():
         ('equal', 'e', 4, 'e', 5),
         ('equal', 'f', 5, 'f', 6),
         ('delete', 'g', 6, None, None),
-    ]
+    ]:
+        raise AssertionError

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -14,12 +14,15 @@ def test_partition_node_list_no_nodes():
 
 
 def test_name_mutation_simple_mutants():
-    assert name_mutation(None, 'True') == 'False'
+    if name_mutation(None, 'True') != 'False':
+        raise AssertionError
 
 
 def test_context_exclude_line():
     source = "__import__('pkg_resources').declare_namespace(__name__)\n"
-    assert mutate(Context(source=source)) == (source, 0)
+    if mutate(Context(source=source)) != (source, 0):
+        raise AssertionError
 
     source = "__all__ = ['hi']\n"
-    assert mutate(Context(source=source)) == (source, 0)
+    if mutate(Context(source=source)) != (source, 0):
+        raise AssertionError

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -115,45 +115,78 @@ def test_compute_return_code():
             self.surviving_mutants_timeout = surviving_mutants_timeout
             self.suspicious_mutants = suspicious_mutants
 
-    assert compute_exit_code(MockProgress(0, 0, 0, 0)) == 0
-    assert compute_exit_code(MockProgress(0, 0, 0, 1)) == 8
-    assert compute_exit_code(MockProgress(0, 0, 1, 0)) == 4
-    assert compute_exit_code(MockProgress(0, 0, 1, 1)) == 12
-    assert compute_exit_code(MockProgress(0, 1, 0, 0)) == 2
-    assert compute_exit_code(MockProgress(0, 1, 0, 1)) == 10
-    assert compute_exit_code(MockProgress(0, 1, 1, 0)) == 6
-    assert compute_exit_code(MockProgress(0, 1, 1, 1)) == 14
+    if compute_exit_code(MockProgress(0, 0, 0, 0)) != 0:
+        raise AssertionError
+    if compute_exit_code(MockProgress(0, 0, 0, 1)) != 8:
+        raise AssertionError
+    if compute_exit_code(MockProgress(0, 0, 1, 0)) != 4:
+        raise AssertionError
+    if compute_exit_code(MockProgress(0, 0, 1, 1)) != 12:
+        raise AssertionError
+    if compute_exit_code(MockProgress(0, 1, 0, 0)) != 2:
+        raise AssertionError
+    if compute_exit_code(MockProgress(0, 1, 0, 1)) != 10:
+        raise AssertionError
+    if compute_exit_code(MockProgress(0, 1, 1, 0)) != 6:
+        raise AssertionError
+    if compute_exit_code(MockProgress(0, 1, 1, 1)) != 14:
+        raise AssertionError
 
-    assert compute_exit_code(MockProgress(1, 0, 0, 0)) == 0
-    assert compute_exit_code(MockProgress(1, 0, 0, 1)) == 8
-    assert compute_exit_code(MockProgress(1, 0, 1, 0)) == 4
-    assert compute_exit_code(MockProgress(1, 0, 1, 1)) == 12
-    assert compute_exit_code(MockProgress(1, 1, 0, 0)) == 2
-    assert compute_exit_code(MockProgress(1, 1, 0, 1)) == 10
-    assert compute_exit_code(MockProgress(1, 1, 1, 0)) == 6
-    assert compute_exit_code(MockProgress(1, 1, 1, 1)) == 14
+    if compute_exit_code(MockProgress(1, 0, 0, 0)) != 0:
+        raise AssertionError
+    if compute_exit_code(MockProgress(1, 0, 0, 1)) != 8:
+        raise AssertionError
+    if compute_exit_code(MockProgress(1, 0, 1, 0)) != 4:
+        raise AssertionError
+    if compute_exit_code(MockProgress(1, 0, 1, 1)) != 12:
+        raise AssertionError
+    if compute_exit_code(MockProgress(1, 1, 0, 0)) != 2:
+        raise AssertionError
+    if compute_exit_code(MockProgress(1, 1, 0, 1)) != 10:
+        raise AssertionError
+    if compute_exit_code(MockProgress(1, 1, 1, 0)) != 6:
+        raise AssertionError
+    if compute_exit_code(MockProgress(1, 1, 1, 1)) != 14:
+        raise AssertionError
 
-    assert compute_exit_code(MockProgress(0, 0, 0, 0), Exception()) == 1
-    assert compute_exit_code(MockProgress(0, 0, 0, 1), Exception()) == 9
-    assert compute_exit_code(MockProgress(0, 0, 1, 0), Exception()) == 5
-    assert compute_exit_code(MockProgress(0, 0, 1, 1), Exception()) == 13
-    assert compute_exit_code(MockProgress(0, 1, 0, 0), Exception()) == 3
-    assert compute_exit_code(MockProgress(0, 1, 0, 1), Exception()) == 11
-    assert compute_exit_code(MockProgress(0, 1, 1, 0), Exception()) == 7
-    assert compute_exit_code(MockProgress(0, 1, 1, 1), Exception()) == 15
+    if compute_exit_code(MockProgress(0, 0, 0, 0), Exception()) != 1:
+        raise AssertionError
+    if compute_exit_code(MockProgress(0, 0, 0, 1), Exception()) != 9:
+        raise AssertionError
+    if compute_exit_code(MockProgress(0, 0, 1, 0), Exception()) != 5:
+        raise AssertionError
+    if compute_exit_code(MockProgress(0, 0, 1, 1), Exception()) != 13:
+        raise AssertionError
+    if compute_exit_code(MockProgress(0, 1, 0, 0), Exception()) != 3:
+        raise AssertionError
+    if compute_exit_code(MockProgress(0, 1, 0, 1), Exception()) != 11:
+        raise AssertionError
+    if compute_exit_code(MockProgress(0, 1, 1, 0), Exception()) != 7:
+        raise AssertionError
+    if compute_exit_code(MockProgress(0, 1, 1, 1), Exception()) != 15:
+        raise AssertionError
 
-    assert compute_exit_code(MockProgress(1, 0, 0, 0), Exception()) == 1
-    assert compute_exit_code(MockProgress(1, 0, 0, 1), Exception()) == 9
-    assert compute_exit_code(MockProgress(1, 0, 1, 0), Exception()) == 5
-    assert compute_exit_code(MockProgress(1, 0, 1, 1), Exception()) == 13
-    assert compute_exit_code(MockProgress(1, 1, 0, 0), Exception()) == 3
-    assert compute_exit_code(MockProgress(1, 1, 0, 1), Exception()) == 11
-    assert compute_exit_code(MockProgress(1, 1, 1, 0), Exception()) == 7
-    assert compute_exit_code(MockProgress(1, 1, 1, 1), Exception()) == 15
+    if compute_exit_code(MockProgress(1, 0, 0, 0), Exception()) != 1:
+        raise AssertionError
+    if compute_exit_code(MockProgress(1, 0, 0, 1), Exception()) != 9:
+        raise AssertionError
+    if compute_exit_code(MockProgress(1, 0, 1, 0), Exception()) != 5:
+        raise AssertionError
+    if compute_exit_code(MockProgress(1, 0, 1, 1), Exception()) != 13:
+        raise AssertionError
+    if compute_exit_code(MockProgress(1, 1, 0, 0), Exception()) != 3:
+        raise AssertionError
+    if compute_exit_code(MockProgress(1, 1, 0, 1), Exception()) != 11:
+        raise AssertionError
+    if compute_exit_code(MockProgress(1, 1, 1, 0), Exception()) != 7:
+        raise AssertionError
+    if compute_exit_code(MockProgress(1, 1, 1, 1), Exception()) != 15:
+        raise AssertionError
 
 
 def test_read_coverage_data(filesystem):
-    assert read_coverage_data() == {}
+    if read_coverage_data() != {}:
+        raise AssertionError
 
 
 @pytest.mark.parametrize(
@@ -166,7 +199,8 @@ def test_read_coverage_data(filesystem):
     ]
 )
 def test_python_source_files(expected, source_path, tests_dirs, filesystem):
-    assert list(python_source_files(source_path, tests_dirs)) == expected
+    if list(python_source_files(source_path, tests_dirs)) != expected:
+        raise AssertionError
 
 
 def test_python_source_files__with_paths_to_exclude(tmpdir):
@@ -194,10 +228,11 @@ def test_python_source_files__with_paths_to_exclude(tmpdir):
         pass
 
     # act, assert
-    assert set(python_source_files(project_dir, [], paths_to_exclude)) == {
+    if set(python_source_files(project_dir, [], paths_to_exclude)) != {
         os.path.join(project_dir, 'services', 'main.py'),
         os.path.join(project_dir, 'services', 'utils.py'),
-    }
+    }:
+        raise AssertionError
 
 
 def test_popen_streaming_output_timeout():
@@ -208,7 +243,8 @@ def test_popen_streaming_output_timeout():
             lambda line: line, timeout=0.1,
         )
 
-    assert (time() - start) < 3
+    if (time() - start) >= 3:
+        raise AssertionError
 
 
 def test_popen_streaming_output_stream():
@@ -242,44 +278,56 @@ def test_popen_streaming_output_stream():
 def test_simple_apply(filesystem):
     result = CliRunner().invoke(climain, ['run', '-s', '--paths-to-mutate=foo.py', "--test-time-base=15.0"], catch_exceptions=False)
     print(repr(result.output))
-    assert result.exit_code == 0
+    if result.exit_code != 0:
+        raise AssertionError
 
     result = CliRunner().invoke(climain, ['apply', '1'], catch_exceptions=False)
     print(repr(result.output))
-    assert result.exit_code == 0
+    if result.exit_code != 0:
+        raise AssertionError
     with open(os.path.join(str(filesystem), 'foo.py')) as f:
-        assert f.read() != file_to_mutate_contents
+        if f.read() == file_to_mutate_contents:
+            raise AssertionError
 
 
 def test_full_run_no_surviving_mutants(filesystem):
     result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0"], catch_exceptions=False)
     print(repr(result.output))
-    assert result.exit_code == 0
+    if result.exit_code != 0:
+        raise AssertionError
     result = CliRunner().invoke(climain, ['results'], catch_exceptions=False)
     print(repr(result.output))
-    assert result.exit_code == 0
-    assert result.output.strip() == u"""
+    if result.exit_code != 0:
+        raise AssertionError
+    if result.output.strip() != u"""
 To apply a mutant on disk:
     mutmut apply <id>
 
 To show a mutant:
     mutmut show <id>
-""".strip()
+""".strip():
+        raise AssertionError
 
 
 def test_full_run_no_surviving_mutants_junit(filesystem):
     result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0"], catch_exceptions=False)
     print(repr(result.output))
-    assert result.exit_code == 0
+    if result.exit_code != 0:
+        raise AssertionError
 
     result = CliRunner().invoke(climain, ['junitxml'], catch_exceptions=False)
     print(repr(result.output))
-    assert result.exit_code == 0
+    if result.exit_code != 0:
+        raise AssertionError
     root = ET.fromstring(result.output.strip())
-    assert int(root.attrib['tests']) == EXPECTED_MUTANTS
-    assert int(root.attrib['failures']) == 0
-    assert int(root.attrib['errors']) == 0
-    assert int(root.attrib['disabled']) == 0
+    if int(root.attrib['tests']) != EXPECTED_MUTANTS:
+        raise AssertionError
+    if int(root.attrib['failures']) != 0:
+        raise AssertionError
+    if int(root.attrib['errors']) != 0:
+        raise AssertionError
+    if int(root.attrib['disabled']) != 0:
+        raise AssertionError
 
 
 def test_full_run_one_surviving_mutant(filesystem):
@@ -288,12 +336,14 @@ def test_full_run_one_surviving_mutant(filesystem):
 
     result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0"], catch_exceptions=False)
     print(repr(result.output))
-    assert result.exit_code == 2
+    if result.exit_code != 2:
+        raise AssertionError
 
     result = CliRunner().invoke(climain, ['results'], catch_exceptions=False)
     print(repr(result.output))
-    assert result.exit_code == 0
-    assert result.output.strip() == u"""
+    if result.exit_code != 0:
+        raise AssertionError
+    if result.output.strip() != u"""
 To apply a mutant on disk:
     mutmut apply <id>
 
@@ -306,7 +356,8 @@ Survived 🙁 (1)
 ---- foo.py (1) ----
 
 1
-""".strip()
+""".strip():
+        raise AssertionError
 
 
 def test_full_run_one_surviving_mutant_junit(filesystem):
@@ -315,26 +366,34 @@ def test_full_run_one_surviving_mutant_junit(filesystem):
 
     result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0"], catch_exceptions=False)
     print(repr(result.output))
-    assert result.exit_code == 2
+    if result.exit_code != 2:
+        raise AssertionError
 
     result = CliRunner().invoke(climain, ['junitxml'], catch_exceptions=False)
     print(repr(result.output))
-    assert result.exit_code == 0
+    if result.exit_code != 0:
+        raise AssertionError
     root = ET.fromstring(result.output.strip())
-    assert int(root.attrib['tests']) == EXPECTED_MUTANTS
-    assert int(root.attrib['failures']) == 1
-    assert int(root.attrib['errors']) == 0
-    assert int(root.attrib['disabled']) == 0
+    if int(root.attrib['tests']) != EXPECTED_MUTANTS:
+        raise AssertionError
+    if int(root.attrib['failures']) != 1:
+        raise AssertionError
+    if int(root.attrib['errors']) != 0:
+        raise AssertionError
+    if int(root.attrib['disabled']) != 0:
+        raise AssertionError
 
 
 def test_full_run_all_suspicious_mutant(filesystem):
     result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-multiplier=0.0"], catch_exceptions=False)
     print(repr(result.output))
-    assert result.exit_code == 8
+    if result.exit_code != 8:
+        raise AssertionError
     result = CliRunner().invoke(climain, ['results'], catch_exceptions=False)
     print(repr(result.output))
-    assert result.exit_code == 0
-    assert result.output.strip() == u"""
+    if result.exit_code != 0:
+        raise AssertionError
+    if result.output.strip() != u"""
 To apply a mutant on disk:
     mutmut apply <id>
 
@@ -347,21 +406,28 @@ Suspicious 🤔 ({EXPECTED_MUTANTS})
 ---- foo.py ({EXPECTED_MUTANTS}) ----
 
 1-{EXPECTED_MUTANTS}
-""".format(EXPECTED_MUTANTS=EXPECTED_MUTANTS).strip()
+""".format(EXPECTED_MUTANTS=EXPECTED_MUTANTS).strip():
+        raise AssertionError
 
 
 def test_full_run_all_suspicious_mutant_junit(filesystem):
     result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-multiplier=0.0"], catch_exceptions=False)
     print(repr(result.output))
-    assert result.exit_code == 8
+    if result.exit_code != 8:
+        raise AssertionError
     result = CliRunner().invoke(climain, ['junitxml'], catch_exceptions=False)
     print(repr(result.output))
-    assert result.exit_code == 0
+    if result.exit_code != 0:
+        raise AssertionError
     root = ET.fromstring(result.output.strip())
-    assert int(root.attrib['tests']) == EXPECTED_MUTANTS
-    assert int(root.attrib['failures']) == 0
-    assert int(root.attrib['errors']) == 0
-    assert int(root.attrib['disabled']) == 0
+    if int(root.attrib['tests']) != EXPECTED_MUTANTS:
+        raise AssertionError
+    if int(root.attrib['failures']) != 0:
+        raise AssertionError
+    if int(root.attrib['errors']) != 0:
+        raise AssertionError
+    if int(root.attrib['disabled']) != 0:
+        raise AssertionError
 
 
 def test_use_coverage(filesystem):
@@ -371,25 +437,34 @@ def test_use_coverage(filesystem):
     # first validate that mutmut without coverage detects a surviving mutant
     result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0"], catch_exceptions=False)
     print(repr(result.output))
-    assert result.exit_code == 2
+    if result.exit_code != 2:
+        raise AssertionError
 
     result = CliRunner().invoke(climain, ['junitxml'], catch_exceptions=False)
     print(repr(result.output))
-    assert result.exit_code == 0
+    if result.exit_code != 0:
+        raise AssertionError
     root = ET.fromstring(result.output.strip())
-    assert int(root.attrib['tests']) == EXPECTED_MUTANTS
-    assert int(root.attrib['failures']) == 1
-    assert int(root.attrib['errors']) == 0
-    assert int(root.attrib['disabled']) == 0
+    if int(root.attrib['tests']) != EXPECTED_MUTANTS:
+        raise AssertionError
+    if int(root.attrib['failures']) != 1:
+        raise AssertionError
+    if int(root.attrib['errors']) != 0:
+        raise AssertionError
+    if int(root.attrib['disabled']) != 0:
+        raise AssertionError
 
     # generate a `.coverage` file by invoking pytest
     subprocess.run([sys.executable, "-m", "pytest", "--cov=.", "foo.py"])
-    assert os.path.isfile('.coverage')
+    if not os.path.isfile('.coverage'):
+        raise AssertionError
 
     result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0", "--use-coverage"], catch_exceptions=False)
     print(repr(result.output))
-    assert result.exit_code == 0
-    assert '13/13  🎉 13  ⏰ 0  🤔 0  🙁 0' in repr(result.output)
+    if result.exit_code != 0:
+        raise AssertionError
+    if '13/13  🎉 13  ⏰ 0  🤔 0  🙁 0' not in repr(result.output):
+        raise AssertionError
 
     # remove existent path to check if an exception is thrown
     os.unlink(os.path.join(str(filesystem), 'foo.py'))
@@ -420,8 +495,10 @@ index b9a5fb4..c6a496c 100644
 
     result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0", "--use-patch-file=patch"], catch_exceptions=False)
     print(repr(result.output))
-    assert result.exit_code == 0
-    assert '2/2  🎉 2  ⏰ 0  🤔 0  🙁 0' in repr(result.output)
+    if result.exit_code != 0:
+        raise AssertionError
+    if '2/2  🎉 2  ⏰ 0  🤔 0  🙁 0' not in repr(result.output):
+        raise AssertionError
 
 
 def test_pre_and_post_mutation_hook(single_mutant_filesystem, tmpdir):
@@ -437,7 +514,11 @@ def test_pre_and_post_mutation_hook(single_mutant_filesystem, tmpdir):
             "--post-mutation=echo post mutation stub",
         ], catch_exceptions=False)
     print(result.output)
-    assert result.exit_code == 0
-    assert "pre mutation stub" in result.output
-    assert "post mutation stub" in result.output
-    assert result.output.index("pre mutation stub") < result.output.index("post mutation stub")
+    if result.exit_code != 0:
+        raise AssertionError
+    if "pre mutation stub" not in result.output:
+        raise AssertionError
+    if "post mutation stub" not in result.output:
+        raise AssertionError
+    if result.output.index("pre mutation stub") >= result.output.index("post mutation stub"):
+        raise AssertionError

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -9,21 +9,28 @@ from mutmut import mutate, ALL, Context, list_mutations, RelativeMutationID, \
 
 def test_matches_py3():
     node = parse('a: Optional[int] = 7\n').children[0].children[0].children[1].children[1].children[1].children[1]
-    assert not array_subscript_pattern.matches(node=node)
+    if array_subscript_pattern.matches(node=node):
+        raise AssertionError
 
 
 def test_matches():
     node = parse('from foo import bar').children[0]
-    assert not array_subscript_pattern.matches(node=node)
-    assert not function_call_pattern.matches(node=node)
-    assert not array_subscript_pattern.matches(node=node)
-    assert not function_call_pattern.matches(node=node)
+    if array_subscript_pattern.matches(node=node):
+        raise AssertionError
+    if function_call_pattern.matches(node=node):
+        raise AssertionError
+    if array_subscript_pattern.matches(node=node):
+        raise AssertionError
+    if function_call_pattern.matches(node=node):
+        raise AssertionError
 
     node = parse('foo[bar]\n').children[0].children[0].children[1].children[1]
-    assert array_subscript_pattern.matches(node=node)
+    if not array_subscript_pattern.matches(node=node):
+        raise AssertionError
 
     node = parse('foo(bar)\n').children[0].children[0].children[1].children[1]
-    assert function_call_pattern.matches(node=node)
+    if not function_call_pattern.matches(node=node):
+        raise AssertionError
 
 
 def test_ast_pattern_for_loop():
@@ -50,13 +57,15 @@ for x in y:
     if foo:
         continue
 """).children[0].children[3]
-    assert p.matches(node=n)
+    if not p.matches(node=n):
+        raise AssertionError
 
     n = parse("""for a, b in [1, 2, 3]:
     if foo:
         continue
 """).children[0].children[3]
-    assert p.matches(node=n)
+    if not p.matches(node=n):
+        raise AssertionError
 
 
 @pytest.mark.parametrize(
@@ -112,7 +121,8 @@ for x in y:
 )
 def test_basic_mutations(original, expected):
     actual, number_of_performed_mutations = mutate(Context(source=original, mutation_id=ALL, dict_synonyms=['Struct', 'FooBarDict']))
-    assert actual == expected, 'Performed {} mutations for original "{}"'.format(number_of_performed_mutations, original)
+    if actual != expected:
+        raise AssertionError('Performed {} mutations for original "{}"'.format(number_of_performed_mutations, original))
 
 
 @pytest.mark.parametrize(
@@ -133,9 +143,12 @@ def test_basic_mutations(original, expected):
 )
 def test_multiple_mutations(original, expected):
     mutations = list_mutations(Context(source=original))
-    assert len(mutations) == 3
-    assert mutate(Context(source=original, mutation_id=mutations[0])) == (expected[0], 1)
-    assert mutate(Context(source=original, mutation_id=mutations[1])) == (expected[1], 1)
+    if len(mutations) != 3:
+        raise AssertionError
+    if mutate(Context(source=original, mutation_id=mutations[0])) != (expected[0], 1):
+        raise AssertionError
+    if mutate(Context(source=original, mutation_id=mutations[1])) != (expected[1], 1):
+        raise AssertionError
 
 
 @pytest.mark.parametrize(
@@ -150,7 +163,8 @@ def test_multiple_mutations(original, expected):
 )
 def test_basic_mutations_python3(original, expected):
     actual = mutate(Context(source=original, mutation_id=ALL, dict_synonyms=['Struct', 'FooBarDict']))[0]
-    assert actual == expected
+    if actual != expected:
+        raise AssertionError
 
 
 @pytest.mark.parametrize(
@@ -161,7 +175,8 @@ def test_basic_mutations_python3(original, expected):
 )
 def test_basic_mutations_python36(original, expected):
     actual = mutate(Context(source=original, mutation_id=ALL, dict_synonyms=['Struct', 'FooBarDict']))[0]
-    assert actual == expected
+    if actual != expected:
+        raise AssertionError
 
 
 @pytest.mark.parametrize(
@@ -183,7 +198,8 @@ def test_basic_mutations_python36(original, expected):
 )
 def test_do_not_mutate(source):
     actual = mutate(Context(source=source, mutation_id=ALL, dict_synonyms=['Struct', 'FooBarDict']))[0]
-    assert actual == source
+    if actual != source:
+        raise AssertionError
 
 
 @pytest.mark.parametrize(
@@ -196,7 +212,8 @@ def test_do_not_mutate(source):
 )
 def test_do_not_mutate_python3(source):
     actual = mutate(Context(source=source, mutation_id=ALL, dict_synonyms=['Struct', 'FooBarDict']))[0]
-    assert actual == source
+    if actual != source:
+        raise AssertionError
 
 
 def test_mutate_body_of_function_with_return_type_annotation():
@@ -205,25 +222,33 @@ def foo() -> int:
     return 0
     """
 
-    assert mutate(Context(source=source, mutation_id=ALL))[0] == source.replace('0', '1')
+    if mutate(Context(source=source, mutation_id=ALL))[0] != source.replace('0', '1'):
+        raise AssertionError
 
 
 def test_mutate_all():
-    assert mutate(Context(source='def foo():\n    return 1+1', mutation_id=ALL)) == ('def foo():\n    return 2-2', 3)
+    if mutate(Context(source='def foo():\n    return 1+1', mutation_id=ALL)) != ('def foo():\n    return 2-2', 3):
+        raise AssertionError
 
 
 def test_mutate_both():
     source = 'a = b + c'
     mutations = list_mutations(Context(source=source))
-    assert len(mutations) == 2
-    assert mutate(Context(source=source, mutation_id=mutations[0])) == ('a = b - c', 1)
-    assert mutate(Context(source=source, mutation_id=mutations[1])) == ('a = None', 1)
+    if len(mutations) != 2:
+        raise AssertionError
+    if mutate(Context(source=source, mutation_id=mutations[0])) != ('a = b - c', 1):
+        raise AssertionError
+    if mutate(Context(source=source, mutation_id=mutations[1])) != ('a = None', 1):
+        raise AssertionError
 
 
 def test_perform_one_indexed_mutation():
-    assert mutate(Context(source='1+1', mutation_id=RelativeMutationID(line='1+1', index=0, line_number=0))) == ('2+1', 1)
-    assert mutate(Context(source='1+1', mutation_id=RelativeMutationID('1+1', 1, line_number=0))) == ('1-1', 1)
-    assert mutate(Context(source='1+1', mutation_id=RelativeMutationID('1+1', 2, line_number=0))) == ('1+2', 1)
+    if mutate(Context(source='1+1', mutation_id=RelativeMutationID(line='1+1', index=0, line_number=0))) != ('2+1', 1):
+        raise AssertionError
+    if mutate(Context(source='1+1', mutation_id=RelativeMutationID('1+1', 1, line_number=0))) != ('1-1', 1):
+        raise AssertionError
+    if mutate(Context(source='1+1', mutation_id=RelativeMutationID('1+1', 2, line_number=0))) != ('1+2', 1):
+        raise AssertionError
 
     # TODO: should this case raise an exception?
     # assert mutate(Context(source='def foo():\n    return 1', mutation_id=2)) == ('def foo():\n    return 1\n', 0)
@@ -231,29 +256,36 @@ def test_perform_one_indexed_mutation():
 
 def test_function():
     source = "def capitalize(s):\n    return s[0].upper() + s[1:] if s else s\n"
-    assert mutate(Context(source=source, mutation_id=RelativeMutationID(source.split('\n')[1], 0, line_number=1))) == ("def capitalize(s):\n    return s[1].upper() + s[1:] if s else s\n", 1)
-    assert mutate(Context(source=source, mutation_id=RelativeMutationID(source.split('\n')[1], 1, line_number=1))) == ("def capitalize(s):\n    return s[0].upper() - s[1:] if s else s\n", 1)
-    assert mutate(Context(source=source, mutation_id=RelativeMutationID(source.split('\n')[1], 2, line_number=1))) == ("def capitalize(s):\n    return s[0].upper() + s[2:] if s else s\n", 1)
+    if mutate(Context(source=source, mutation_id=RelativeMutationID(source.split('\n')[1], 0, line_number=1))) != ("def capitalize(s):\n    return s[1].upper() + s[1:] if s else s\n", 1):
+        raise AssertionError
+    if mutate(Context(source=source, mutation_id=RelativeMutationID(source.split('\n')[1], 1, line_number=1))) != ("def capitalize(s):\n    return s[0].upper() - s[1:] if s else s\n", 1):
+        raise AssertionError
+    if mutate(Context(source=source, mutation_id=RelativeMutationID(source.split('\n')[1], 2, line_number=1))) != ("def capitalize(s):\n    return s[0].upper() + s[2:] if s else s\n", 1):
+        raise AssertionError
 
 
 def test_function_with_annotation():
     source = "def capitalize(s : str):\n    return s[0].upper() + s[1:] if s else s\n"
-    assert mutate(Context(source=source, mutation_id=RelativeMutationID(source.split('\n')[1], 0, line_number=1))) == ("def capitalize(s : str):\n    return s[1].upper() + s[1:] if s else s\n", 1)
+    if mutate(Context(source=source, mutation_id=RelativeMutationID(source.split('\n')[1], 0, line_number=1))) != ("def capitalize(s : str):\n    return s[1].upper() + s[1:] if s else s\n", 1):
+        raise AssertionError
 
 
 def test_pragma_no_mutate():
     source = """def foo():\n    return 1+1  # pragma: no mutate\n"""
-    assert mutate(Context(source=source, mutation_id=ALL)) == (source, 0)
+    if mutate(Context(source=source, mutation_id=ALL)) != (source, 0):
+        raise AssertionError
 
 
 def test_pragma_no_mutate_and_no_cover():
     source = """def foo():\n    return 1+1  # pragma: no cover, no mutate\n"""
-    assert mutate(Context(source=source, mutation_id=ALL)) == (source, 0)
+    if mutate(Context(source=source, mutation_id=ALL)) != (source, 0):
+        raise AssertionError
 
 
 def test_mutate_decorator():
     source = """@foo\ndef foo():\n    pass\n"""
-    assert mutate(Context(source=source, mutation_id=ALL)) == (source.replace('@foo', ''), 1)
+    if mutate(Context(source=source, mutation_id=ALL)) != (source.replace('@foo', ''), 1):
+        raise AssertionError
 
 
 # TODO: getting this test and the above to both pass is tricky
@@ -264,12 +296,14 @@ def test_mutate_decorator():
 
 def test_mutate_dict():
     source = "dict(a=b, c=d)"
-    assert mutate(Context(source=source, mutation_id=RelativeMutationID(source, 1, line_number=0))) == ("dict(a=b, cXX=d)", 1)
+    if mutate(Context(source=source, mutation_id=RelativeMutationID(source, 1, line_number=0))) != ("dict(a=b, cXX=d)", 1):
+        raise AssertionError
 
 
 def test_mutate_dict2():
     source = "dict(a=b, c=d, e=f, g=h)"
-    assert mutate(Context(source=source, mutation_id=RelativeMutationID(source, 3, line_number=0))) == ("dict(a=b, c=d, e=f, gXX=h)", 1)
+    if mutate(Context(source=source, mutation_id=RelativeMutationID(source, 3, line_number=0))) != ("dict(a=b, c=d, e=f, gXX=h)", 1):
+        raise AssertionError
 
 
 def test_performed_mutation_ids():
@@ -277,7 +311,8 @@ def test_performed_mutation_ids():
     context = Context(source=source)
     mutate(context)
     # we found two mutation points: mutate "a" and "c"
-    assert context.performed_mutation_ids == [RelativeMutationID(source, 0, 0), RelativeMutationID(source, 1, 0)]
+    if context.performed_mutation_ids != [RelativeMutationID(source, 0, 0), RelativeMutationID(source, 1, 0)]:
+        raise AssertionError
 
 
 def test_syntax_error():
@@ -333,7 +368,8 @@ def test_bug_github_issue_30():
 def from_checker(cls: Type['BaseVisitor'], checker) -> 'BaseVisitor':
     pass
 """
-    assert mutate(Context(source=source)) == (source, 0)
+    if mutate(Context(source=source)) != (source, 0):
+        raise AssertionError
 
 
 def test_bug_github_issue_77():
@@ -350,7 +386,8 @@ __all__ = [
     'bar',
 ]
 """
-    assert mutate(Context(source=source)) == (source, 0)
+    if mutate(Context(source=source)) != (source, 0):
+        raise AssertionError
 
 
 def test_bug_github_issue_162():
@@ -358,11 +395,13 @@ def test_bug_github_issue_162():
 primes: List[int] = []
 foo = 'bar'
 """
-    assert mutate(Context(source=source, mutation_id=RelativeMutationID("foo = 'bar'", 0, 2))) == (source.replace("'bar'", "'XXbarXX'"), 1)
+    if mutate(Context(source=source, mutation_id=RelativeMutationID("foo = 'bar'", 0, 2))) != (source.replace("'bar'", "'XXbarXX'"), 1):
+        raise AssertionError
 
 
 def test_bad_mutation_str_type_definition():
     source = """
 foo: 'SomeType'
     """
-    assert mutate(Context(source=source)) == (source, 0)
+    if mutate(Context(source=source)) != (source, 0):
+        raise AssertionError


### PR DESCRIPTION
This pull request fixes some of the quality issues raised by DeepSource on my fork of this repository.

Summary of fixes:

- Refactor unnecessary `else` / `elif` when `if` block has a `return` statement 
- Remove assert statement from non-test files 
- Refactor unnecessary `else` / `elif` when `if` block has a `break` statement 
- Remove implicit `object` from the base class 

You can see all the issues raised by DeepSource [here](https://deepsource.io/gh/HarshCasper/mutmut/).

These Issues were fixed automatically by DeepSource

### Using DeepSource to continuously analyze your repository

- Merge this PR. I have included a `.deepsource.toml` in this PR, which you can use to configure your analysis settings.
- Install DeepSource on your repository [here](https://deepsource.io/signup).
- Activate analysis [here](https://deepsource.io/gh/boxed/mutmut).

If you do not want to use DeepSource to continuously analyze this repo, I'll remove the `.deepsource.toml` from this PR and you can merge the rest of the fixes.