### PR TITLE
Add python_requires metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup(
     license="BSD",
     zip_safe=False,
     keywords='mutmut mutant mutation test testing',
+    python_requires='>=3.7',
     install_requires=read_reqs('requirements.txt'),
     extras_require=extras_reqs,
     tests_require=test_reqs,


### PR DESCRIPTION
This metadata helps pip not install versions of `mutmut` that don't support the interpreter in use.