### PR TITLE
Add ability to update progress output only after test passes

### DIFF
--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -805,7 +805,7 @@ class Config(object):
                  baseline_time_elapsed, test_time_multiplier, test_time_base,
                  backup, dict_synonyms, total, using_testmon, cache_only,
                  tests_dirs, hash_of_tests, pre_mutation, post_mutation,
-                 coverage_data, paths_to_mutate):
+                 coverage_data, paths_to_mutate, no_progress):
         self.swallow_output = swallow_output
         self.test_command = test_command
         self.covered_lines_by_filename = covered_lines_by_filename
@@ -823,6 +823,7 @@ class Config(object):
         self.pre_mutation = pre_mutation
         self.coverage_data = coverage_data
         self.paths_to_mutate = paths_to_mutate
+        self.no_progress = no_progress
 
 
 def tests_pass(config: Config, callback) -> bool:
@@ -1154,7 +1155,7 @@ def run_mutation_tests(config, progress, mutations_by_file):
         elif command == 'progress':
             if not config.swallow_output:
                 print(status, end='', flush=True)
-            else:
+            elif not config.no_progress:
                 progress.print()
 
         else:
@@ -1163,8 +1164,6 @@ def run_mutation_tests(config, progress, mutations_by_file):
             progress.register(status)
 
             update_mutant_status(file_to_mutate=filename, mutation_id=mutation_id, status=status, tests_hash=config.hash_of_tests)
-
-            progress.print()
 
 
 def read_coverage_data():

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -104,6 +104,7 @@ DEFAULT_RUNNER = 'python -m pytest -x --assert=plain'
 @click.option('--pre-mutation')
 @click.option('--post-mutation')
 @click.option('--simple-output', is_flag=True, default=False, help="Swap emojis in mutmut output to plain text alternatives.")
+@click.option('--no-progress', is_flag=True, default=False, help="Disable real-time progress indicator")
 @config_from_setup_cfg(
     dict_synonyms='',
     paths_to_exclude='',
@@ -117,7 +118,7 @@ def climain(command, argument, argument2, paths_to_mutate, backup, runner, tests
             test_time_multiplier, test_time_base,
             swallow_output, use_coverage, dict_synonyms, cache_only, version,
             suspicious_policy, untested_policy, pre_mutation, post_mutation,
-            use_patch_file, paths_to_exclude, simple_output):
+            use_patch_file, paths_to_exclude, simple_output, no_progress):
     """
 commands:\n
     run [mutation id]\n
@@ -141,14 +142,15 @@ commands:\n
                   tests_dir, test_time_multiplier, test_time_base,
                   swallow_output, use_coverage, dict_synonyms, cache_only,
                   version, suspicious_policy, untested_policy, pre_mutation,
-                  post_mutation, use_patch_file, paths_to_exclude, simple_output))
+                  post_mutation, use_patch_file, paths_to_exclude, simple_output,
+                  no_progress))
 
 
 def main(command, argument, argument2, paths_to_mutate, backup, runner, tests_dir,
          test_time_multiplier, test_time_base,
          swallow_output, use_coverage, dict_synonyms, cache_only, version,
          suspicious_policy, untested_policy, pre_mutation, post_mutation,
-         use_patch_file, paths_to_exclude, simple_output):
+         use_patch_file, paths_to_exclude, simple_output, no_progress):
     """return exit code, after performing an mutation test run.
 
     :return: the exit code from executing the mutation tests
@@ -331,6 +333,7 @@ Legend for output:
         pre_mutation=pre_mutation,
         post_mutation=post_mutation,
         paths_to_mutate=paths_to_mutate,
+        no_progress=no_progress
     )
 
     parse_run_argument(argument, config, dict_synonyms, mutations_by_file, paths_to_exclude, paths_to_mutate, tests_dirs)


### PR DESCRIPTION
Some CI (for example Travis) does not support "\r" sequence and the whole output is logged. That may result in too big file and fail of the CI, see my attempt to integrate mutmut: https://travis-ci.com/github/PatrikValkovic/grammpy/builds/229567121

I add `--no-progress` option to disable real-time output and progress is only shown after one mutation is tested.