### PR TITLE
Add new argument to get all IDs of a certain result category

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,6 +132,9 @@ This section describes how to work with mutmut to enhance your test suite.
 Mutmut keeps a result cache in ``.mutmut-cache`` so if you want to make sure you
 run a full mutmut run just delete this file.
 
+If you want to re-run all survivors after changing a lot of code or even the configuration,
+you can use `for ID in $(mutmut result-ids survived); do mutmut run $ID; done` (for bash).
+
 You can also tell mutmut to just check a single mutant:
 
 .. code-block:: console

--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -188,14 +188,14 @@ BAD_SURVIVED = 'bad_survived'
 SKIPPED = 'skipped'
 
 
-mutant_statuses = [
-    UNTESTED,
-    OK_KILLED,
-    OK_SUSPICIOUS,
-    BAD_TIMEOUT,
-    BAD_SURVIVED,
-    SKIPPED,
-]
+MUTANT_STATUSES = {
+    "killed": OK_KILLED,
+    "timeout": BAD_TIMEOUT,
+    "suspicious": OK_SUSPICIOUS,
+    "survived": BAD_SURVIVED,
+    "skipped": SKIPPED,
+    "untested": UNTESTED,
+}
 
 
 def number_mutation(value, **_):

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -126,7 +126,7 @@ commands:\n
         Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.\n
     results\n
         Print the results.\n
-    results-ids survived (or any other of: killed,timeout,suspicious,skipped,untested)\n
+    result-ids survived (or any other of: killed,timeout,suspicious,skipped,untested)\n
         Print the IDs of the specified mutant classes (separated by spaces).\n
     apply [mutation id]\n
         Apply a mutation on disk.\n

--- a/mutmut/cache.py
+++ b/mutmut/cache.py
@@ -15,7 +15,7 @@ from junit_xml import TestSuite, TestCase
 from pony.orm import Database, Required, db_session, Set, Optional, select, \
     PrimaryKey, RowNotFound, ERDiagramError, OperationalError
 
-from mutmut import BAD_TIMEOUT, OK_SUSPICIOUS, BAD_SURVIVED, UNTESTED, \
+from mutmut import MUTANT_STATUSES, BAD_TIMEOUT, OK_SUSPICIOUS, BAD_SURVIVED, UNTESTED, \
     OK_KILLED, RelativeMutationID, Context, mutate
 
 db = Database()
@@ -187,6 +187,14 @@ def print_result_cache(show_diffs=False, dict_synonyms=None, print_only_filename
     print_stuff('Suspicious 🤔', select(x for x in Mutant if x.status == OK_SUSPICIOUS))
     print_stuff('Survived 🙁', select(x for x in Mutant if x.status == BAD_SURVIVED))
     print_stuff('Untested/skipped', select(x for x in Mutant if x.status == UNTESTED))
+
+
+@init_db
+@db_session
+def print_result_ids_cache(desired_status):
+    status = MUTANT_STATUSES[desired_status]
+    mutant_query = select(x for x in Mutant if x.status == status)
+    print(" ".join(str(mutant.id) for mutant in mutant_query))
 
 
 def get_unified_diff(argument, dict_synonyms, update_cache=True, source=None):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -447,3 +447,10 @@ def test_simple_output(filesystem):
     result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--simple-output"], catch_exceptions=False)
     print(repr(result.output))
     assert '14/14  KILLED 14  TIMEOUT 0  SUSPICIOUS 0  SURVIVED 0  SKIPPED 0' in repr(result.output)
+
+
+def test_simple_output(filesystem):
+    result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--simple-output"], catch_exceptions=False)
+    print(repr(result.output))
+    assert CliRunner().invoke(climain, ['result-ids', "survived"], catch_exceptions=False).output.strip() == "1"
+    assert CliRunner().invoke(climain, ['result-ids', "killed"], catch_exceptions=False).output.strip() == ""


### PR DESCRIPTION
This is useful if you want, for example, to re-run all surviving mutants after changing a lot: `for ID in $(mutmut result-ids survived); do mutmut run $ID; done`. Re-running all mutant checks was not an option (I takes days) and rerunning them manually would also be tedious since there were about 40 of them.