### PR TITLE
fix Windows process invocation when using venv

### DIFF
--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -987,9 +987,10 @@ def popen_streaming_output(cmd, callback, timeout=None):
     """
     if os.name == 'nt':  # pragma: no cover
         process = subprocess.Popen(
-            shlex.split(cmd),
+            cmd,
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
+            stderr=subprocess.STDOUT,
+            shell=True,
         )
         stdout = process.stdout
     else:


### PR DESCRIPTION
`mutmut run` fails without error message if these conditions apply:

* Windows (10 in my case).
* Virtual environment used, where also pytest is installed.

The error message is not shown as the original Windows code caught `stderr` but then ignored the content of `process.stderr`. Instead of adding an explicit print for `stderr` I just redirected `stderr` to `stdout`, which is already printed.

Once I did that I saw the real issue:

```
Output:

C:\Program Files\Python39\python.exe: No module named pytest
```

So mutmut used my system Python interpreter instead of the one from the active venv. venv on Windows injects into `PATH`, see this line from the generated `activate.bat` for instance:

```
set PATH=%VIRTUAL_ENV%\Scripts;%PATH%
```

However from https://bugs.python.org/issue8557:

> [...] on Windows, PATH is only considered when shell=True is also passed.

After setting that, mutmut used my venv interpreter and worked as expected. I then also followed the [Popen recommendation](https://docs.python.org/3/library/subprocess.html#popen-constructor):

> If shell is True, it is recommended to pass args as a string rather than as a sequence.
