### PR TITLE
Add ``--enable-mutation-types`` and ``disable-mutation-types`` options

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,3 +21,4 @@ Credits
 * Roxane Bellott <roxane.bellot@gmail.com>
 * Tomáš Chvátal <tchvatal@suse.com>
 * Felix Divo <https://github.com/felixdivo>
+* Andreas Finkler <andi.finkler@gmail.com>

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+2.3.0
+~~~~~
+
+* Add `--disable-mutation-types` and `--enable-mutation-types` to control what types of mutations are performed
+
 2.2.0
 ~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -178,6 +178,18 @@ or skip logging:
 look at the code for the ``Context`` class for what you can modify. Please
 open a github issue if you need help.
 
+It is also possible to disable mutation of specific node types by passing the
+``--disable-mutation-types`` option. Multiple types can be specified by separating them
+by comma:
+
+.. code-block:: console
+
+    mutmut run --disable-mutation-types=string,decorator
+
+Inversly, you can also only specify to only run specific mutations with ``--enable-mutation-types``.
+Note that ``--disable-mutation-types`` and ``--enable-mutation-types`` are exclusive and cannot
+be combined.
+
 
 JUnit XML support
 -----------------

--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -32,7 +32,7 @@ from time import time
 from parso import parse
 from parso.python.tree import Name, Number, Keyword
 
-__version__ = '2.2.0'
+__version__ = '2.3.0'
 
 
 try:
@@ -597,6 +597,9 @@ def mutate_node(node, context):
             if context.performed_mutation_ids and context.mutation_id != ALL:
                 return
 
+        if context.config and node.type not in context.config.mutation_types_to_apply:
+            return
+
         mutation = mutations_by_type.get(node.type)
 
         if mutation is None:
@@ -805,7 +808,7 @@ class Config(object):
                  baseline_time_elapsed, test_time_multiplier, test_time_base,
                  backup, dict_synonyms, total, using_testmon, cache_only,
                  tests_dirs, hash_of_tests, pre_mutation, post_mutation,
-                 coverage_data, paths_to_mutate, no_progress):
+                 coverage_data, paths_to_mutate, mutation_types_to_apply, no_progress):
         self.swallow_output = swallow_output
         self.test_command = test_command
         self.covered_lines_by_filename = covered_lines_by_filename
@@ -823,6 +826,7 @@ class Config(object):
         self.pre_mutation = pre_mutation
         self.coverage_data = coverage_data
         self.paths_to_mutate = paths_to_mutate
+        self.mutation_types_to_apply = mutation_types_to_apply
         self.no_progress = no_progress
 
 


### PR DESCRIPTION
This PR adds two new command line options:

* ``--enable-mutation-types``: only the specified node types will be mutated
* ``--disable-mutation-types``: all node types except the ones specified will be mutated

Both options can take multiple types separated by comma, e.g.:

```console
mutmut run --disable-mutation-types=string,decorator
```

The types that can be specified are the keys of ``mutations_by_type``. If an unknown type is given to ``mutmut``, it will inform the user of the valid types that are available.

The options are exclusive and can not be combined.

Feedback is welcome!