### PR TITLE
Reenable evaluation of ``mutmut_config.init``

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,8 @@ Changelog
 
 * Add `--disable-mutation-types` and `--enable-mutation-types` to control what types of mutations are performed
 
+* Fixed error where ``mutmut_config.init()`` was not called when running without explicitly having set ``PYTHONPATH``
+
 2.2.0
 ~~~~~
 

--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -35,6 +35,8 @@ from parso.python.tree import Name, Number, Keyword
 __version__ = '2.3.0'
 
 
+if os.getcwd() not in sys.path:
+    sys.path.insert(0, os.getcwd())
 try:
     import mutmut_config
 except ImportError:

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -48,9 +48,6 @@ from mutmut.cache import print_result_cache, print_result_ids_cache, \
 from collections import namedtuple
 import re
 
-if os.getcwd() not in sys.path:
-    sys.path.insert(0, os.getcwd())
-
 
 def do_apply(mutation_pk, dict_synonyms, backup):
     """Apply a specified mutant to the source code
@@ -181,7 +178,7 @@ def main(command, argument, argument2, paths_to_mutate, disable_mutation_types,
         mutation_types_to_apply = set(mutations_by_type.keys())
         invalid_types = None
     if invalid_types:
-        raise click.BadArgumentUsage(f"The following are not valid mutation types: {', '.join(invalid_types)}. Valid mutation types are: {', '.join(mutations_by_type.keys())}")
+        raise click.BadArgumentUsage(f"The following are not valid mutation types: {', '.join(sorted(invalid_types))}. Valid mutation types are: {', '.join(mutations_by_type.keys())}")
 
     valid_commands = ['run', 'results', 'result-ids', 'apply', 'show', 'junitxml', 'html']
     if command not in valid_commands:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -506,7 +506,7 @@ def test_select_unknown_mutation_type(option):
         ]
     )
     assert result.exception.code == 2
-    assert f"The following are not valid mutation types: foo, bar. Valid mutation types are: {', '.join(mutations_by_type.keys())}" in result.output
+    assert f"The following are not valid mutation types: bar, foo. Valid mutation types are: {', '.join(mutations_by_type.keys())}" in result.output, result.output
 
 
 def test_enable_and_disable_mutation_type_are_exclusive():

--- a/tests/test_mutmut_config_hooks.py
+++ b/tests/test_mutmut_config_hooks.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import subprocess
+
+import pytest
+
+
+@pytest.fixture
+def basic_filesystem(tmpdir):
+    source_file = tmpdir / "foo.py"
+    source_file.write("def add(a, b): return a + b")
+    tests_dir = tmpdir / "tests"
+    tests_dir.mkdir()
+    test_file = tests_dir / "test_foo.py"
+    test_file.write("""
+from foo import add
+
+def test_add(): 
+    assert add(1, 1) == 2
+""")
+    mutmut_config_py = tmpdir / "mutmut_config.py"
+    mutmut_config_py.write(f"""
+from pathlib import Path
+
+def init(): 
+    Path("init_hook").touch()
+
+def pre_mutation(context):
+    Path("pre_mutation_hook").touch()
+
+def pre_mutation_ast(context):
+    Path("pre_mutation_ast_hook").touch()
+""")
+    yield tmpdir
+
+
+@pytest.fixture
+def set_working_dir_and_path(basic_filesystem):
+    original_dir = os.path.abspath(os.getcwd())
+    original_path = sys.path[:]
+
+    os.chdir(basic_filesystem)
+    if str(basic_filesystem) in sys.path:
+        sys.path.remove(str(basic_filesystem))
+    
+    yield basic_filesystem
+
+    sys.path = original_path
+    os.chdir(original_dir)
+
+
+@pytest.mark.usefixtures("set_working_dir_and_path")
+def test_hooks(basic_filesystem):
+    subprocess.check_output(["python",  "-m", "mutmut", "run", "--paths-to-mutate=foo.py"])
+    assert (basic_filesystem / "init_hook").exists(), "init was not called."
+    assert (basic_filesystem / "pre_mutation_hook").exists(), "pre_mutation was not called."
+    assert (basic_filesystem / "pre_mutation_ast_hook").exists(), "pre_mutation_ast was not called."


### PR DESCRIPTION
Since Python 3.4 the current working directory is not added to ``sys.path`` when running a console script.
Thus the ``init`` hook was no longer called when running ``mutmut``.

This PR fixes this and closes #224.

Also, I noticed that the test I added for the last PR was flaky, because the output contained the contents of a set.
I fixed it with this PR as well.