### PR TITLE
Use ``Click``'s subcommands

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,10 @@ Changelog
 
 * Fixed error where ``mutmut_config.init()`` was not called when running without explicitly having set ``PYTHONPATH``
 
+* Use ``Click``'s subcommand feature to refactor the command line interface. For the end user, this can now run ``mutmut [COMMAND] -h``
+  to check which parameters are relevant to this specific subcommand. The change is backwards compatible, and all existing commands
+  work the same as before, with the exception of ``mutmut --version``, which now has to be ``mutmut version``.
+
 2.2.0
 ~~~~~
 

--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -808,7 +808,7 @@ def run_mutation(context: Context, callback) -> str:
 class Config(object):
     def __init__(self, swallow_output, test_command, covered_lines_by_filename,
                  baseline_time_elapsed, test_time_multiplier, test_time_base,
-                 backup, dict_synonyms, total, using_testmon, cache_only,
+                 dict_synonyms, total, using_testmon, cache_only,
                  tests_dirs, hash_of_tests, pre_mutation, post_mutation,
                  coverage_data, paths_to_mutate, mutation_types_to_apply, no_progress):
         self.swallow_output = swallow_output
@@ -817,7 +817,6 @@ class Config(object):
         self.baseline_time_elapsed = baseline_time_elapsed
         self.test_time_multipler = test_time_multiplier
         self.test_time_base = test_time_base
-        self.backup = backup
         self.dict_synonyms = dict_synonyms
         self.total = total
         self.using_testmon = using_testmon

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -390,70 +390,19 @@ def show(id_or_file, only_filenames, dict_synonyms):
 
 
 @climain.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.argument('argument', nargs=1, required=False)
-@click.argument('argument2', nargs=1, required=False)
-@click.option('--paths-to-mutate', type=click.STRING)
-@click.option('--disable-mutation-types', type=click.STRING, help='Skip the given types of mutations.')
-@click.option('--enable-mutation-types', type=click.STRING, help='Only perform given types of mutations.')
-@click.option('--paths-to-exclude', type=click.STRING)
-@click.option('--backup/--no-backup', default=False)
-@click.option('--runner')
-@click.option('--use-coverage', is_flag=True, default=False)
-@click.option('--use-patch-file', help='Only mutate lines added/changed in the given patch file')
-@click.option('--tests-dir')
-@click.option('-m', '--test-time-multiplier', default=2.0, type=float)
-@click.option('-b', '--test-time-base', default=0.0, type=float)
-@click.option('-s', '--swallow-output', help='turn off output capture', is_flag=True)
 @click.option('--dict-synonyms')
-@click.option('--cache-only', is_flag=True, default=False)
-@click.option('--version', is_flag=True, default=False)
 @click.option('--suspicious-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
 @click.option('--untested-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
-@click.option('--pre-mutation')
-@click.option('--post-mutation')
-@click.option('--simple-output', is_flag=True, default=False, help="Swap emojis in mutmut output to plain text alternatives.")
-@click.option('--no-progress', is_flag=True, default=False, help="Disable real-time progress indicator")
 @config_from_setup_cfg(
     dict_synonyms='',
-    paths_to_exclude='',
-    runner=DEFAULT_RUNNER,
-    tests_dir='tests/:test/',
-    pre_mutation=None,
-    post_mutation=None,
-    use_patch_file=None,
 )
-def junitxml(argument, argument2, paths_to_mutate, disable_mutation_types, enable_mutation_types,
-            backup, runner, tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage, 
-            dict_synonyms, cache_only, version, suspicious_policy, untested_policy, pre_mutation, 
-            post_mutation, use_patch_file, paths_to_exclude, simple_output, no_progress):
+def junitxml(dict_synonyms, suspicious_policy, untested_policy):
     """
-commands:\n
-    run [mutation id]\n
-        Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.\n
-    results\n
-        Print the results.\n
-    result-ids survived (or any other of: killed,timeout,suspicious,skipped,untested)\n
-        Print the IDs of the specified mutant classes (separated by spaces).\n
-    apply [mutation id]\n
-        Apply a mutation on disk.\n
-    show [mutation id]\n
-        Show a mutation diff.\n
-    show [path to file]\n
-        Show all mutation diffs for this file.\n
     junitxml\n
         Show a mutation diff with junitxml format.
     """
-    if test_time_base is None:  # click sets the default=0.0 to None
-        test_time_base = 0.0
-    if test_time_multiplier is None:  # click sets the default=0.0 to None
-        test_time_multiplier = 0.0
-    sys.exit(main("junitxml", argument, argument2, paths_to_mutate, disable_mutation_types, 
-                  enable_mutation_types, backup, runner,
-                  tests_dir, test_time_multiplier, test_time_base,
-                  swallow_output, use_coverage, dict_synonyms, cache_only,
-                  version, suspicious_policy, untested_policy, pre_mutation,
-                  post_mutation, use_patch_file, paths_to_exclude, simple_output,
-                  no_progress))
+    print_result_cache_junitxml(dict_synonyms, suspicious_policy, untested_policy)
+    sys.exit(0)
 
 
 @climain.command(context_settings=dict(help_option_names=['-h', '--help']))

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -323,70 +323,12 @@ Legend for output:
 
 
 @climain.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.argument('argument', nargs=1, required=False)
-@click.argument('argument2', nargs=1, required=False)
-@click.option('--paths-to-mutate', type=click.STRING)
-@click.option('--disable-mutation-types', type=click.STRING, help='Skip the given types of mutations.')
-@click.option('--enable-mutation-types', type=click.STRING, help='Only perform given types of mutations.')
-@click.option('--paths-to-exclude', type=click.STRING)
-@click.option('--backup/--no-backup', default=False)
-@click.option('--runner')
-@click.option('--use-coverage', is_flag=True, default=False)
-@click.option('--use-patch-file', help='Only mutate lines added/changed in the given patch file')
-@click.option('--tests-dir')
-@click.option('-m', '--test-time-multiplier', default=2.0, type=float)
-@click.option('-b', '--test-time-base', default=0.0, type=float)
-@click.option('-s', '--swallow-output', help='turn off output capture', is_flag=True)
-@click.option('--dict-synonyms')
-@click.option('--cache-only', is_flag=True, default=False)
-@click.option('--version', is_flag=True, default=False)
-@click.option('--suspicious-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
-@click.option('--untested-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
-@click.option('--pre-mutation')
-@click.option('--post-mutation')
-@click.option('--simple-output', is_flag=True, default=False, help="Swap emojis in mutmut output to plain text alternatives.")
-@click.option('--no-progress', is_flag=True, default=False, help="Disable real-time progress indicator")
-@config_from_setup_cfg(
-    dict_synonyms='',
-    paths_to_exclude='',
-    runner=DEFAULT_RUNNER,
-    tests_dir='tests/:test/',
-    pre_mutation=None,
-    post_mutation=None,
-    use_patch_file=None,
-)
-def results(argument, argument2, paths_to_mutate, disable_mutation_types, enable_mutation_types,
-            backup, runner, tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage, 
-            dict_synonyms, cache_only, version, suspicious_policy, untested_policy, pre_mutation, 
-            post_mutation, use_patch_file, paths_to_exclude, simple_output, no_progress):
+def results():
     """
-commands:\n
-    run [mutation id]\n
-        Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.\n
-    results\n
-        Print the results.\n
-    result-ids survived (or any other of: killed,timeout,suspicious,skipped,untested)\n
-        Print the IDs of the specified mutant classes (separated by spaces).\n
-    apply [mutation id]\n
-        Apply a mutation on disk.\n
-    show [mutation id]\n
-        Show a mutation diff.\n
-    show [path to file]\n
-        Show all mutation diffs for this file.\n
-    junitxml\n
-        Show a mutation diff with junitxml format.
+    Print the results.
     """
-    if test_time_base is None:  # click sets the default=0.0 to None
-        test_time_base = 0.0
-    if test_time_multiplier is None:  # click sets the default=0.0 to None
-        test_time_multiplier = 0.0
-    sys.exit(main("results", argument, argument2, paths_to_mutate, disable_mutation_types, 
-                  enable_mutation_types, backup, runner,
-                  tests_dir, test_time_multiplier, test_time_base,
-                  swallow_output, use_coverage, dict_synonyms, cache_only,
-                  version, suspicious_policy, untested_policy, pre_mutation,
-                  post_mutation, use_patch_file, paths_to_exclude, simple_output,
-                  no_progress))
+    print_result_cache()
+    sys.exit(0)
 
 
 @climain.command(context_settings=dict(help_option_names=['-h', '--help']))

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -102,7 +102,6 @@ def version():
 @click.option('--disable-mutation-types', type=click.STRING, help='Skip the given types of mutations.')
 @click.option('--enable-mutation-types', type=click.STRING, help='Only perform given types of mutations.')
 @click.option('--paths-to-exclude', type=click.STRING)
-@click.option('--backup/--no-backup', default=False)
 @click.option('--runner')
 @click.option('--use-coverage', is_flag=True, default=False)
 @click.option('--use-patch-file', help='Only mutate lines added/changed in the given patch file')
@@ -125,7 +124,7 @@ def version():
     post_mutation=None,
     use_patch_file=None,
 )
-def run(argument, paths_to_mutate, disable_mutation_types, enable_mutation_types, backup, runner,
+def run(argument, paths_to_mutate, disable_mutation_types, enable_mutation_types, runner,
         tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage, 
         dict_synonyms, cache_only, pre_mutation, post_mutation, use_patch_file, paths_to_exclude,
         simple_output, no_progress):
@@ -137,7 +136,7 @@ def run(argument, paths_to_mutate, disable_mutation_types, enable_mutation_types
     if test_time_multiplier is None:  # click sets the default=0.0 to None
         test_time_multiplier = 0.0
 
-    sys.exit(do_run(argument, paths_to_mutate, disable_mutation_types, enable_mutation_types, backup, runner,
+    sys.exit(do_run(argument, paths_to_mutate, disable_mutation_types, enable_mutation_types, runner,
                   tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage, 
                   dict_synonyms, cache_only, pre_mutation, post_mutation, use_patch_file, paths_to_exclude,
                   simple_output, no_progress))
@@ -237,7 +236,7 @@ def html(dict_synonyms):
 
 
 def do_run(argument, paths_to_mutate, disable_mutation_types, 
-         enable_mutation_types, backup, runner, tests_dir, test_time_multiplier, test_time_base,
+         enable_mutation_types, runner, tests_dir, test_time_multiplier, test_time_base,
          swallow_output, use_coverage, dict_synonyms, cache_only, pre_mutation, post_mutation,
          use_patch_file, paths_to_exclude, simple_output, no_progress):
     """return exit code, after performing an mutation test run.
@@ -379,7 +378,6 @@ Legend for output:
         covered_lines_by_filename=covered_lines_by_filename,
         coverage_data=coverage_data,
         baseline_time_elapsed=baseline_time_elapsed,
-        backup=backup,
         dict_synonyms=dict_synonyms,
         using_testmon=using_testmon,
         cache_only=cache_only,

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -81,8 +81,37 @@ null_out = open(os.devnull, 'w')
 
 DEFAULT_RUNNER = 'python -m pytest -x --assert=plain'
 
-@click.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.argument('command', nargs=1, required=False)
+@click.group(context_settings=dict(help_option_names=['-h', '--help']))
+@click.option('--version', is_flag=True, default=False)
+def climain(version):
+    """
+commands:\n
+    run [mutation id]\n
+        Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.\n
+    results\n
+        Print the results.\n
+    result-ids survived (or any other of: killed,timeout,suspicious,skipped,untested)\n
+        Print the IDs of the specified mutant classes (separated by spaces).\n
+    apply [mutation id]\n
+        Apply a mutation on disk.\n
+    show [mutation id]\n
+        Show a mutation diff.\n
+    show [path to file]\n
+        Show all mutation diffs for this file.\n
+    junitxml\n
+        Show a mutation diff with junitxml format.
+    """
+    pass
+
+
+@climain.command()
+def version():
+    """Show the version and exit"""
+    print("mutmut version {}".format(__version__))
+    sys.exit(0)
+
+
+@climain.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.argument('argument', nargs=1, required=False)
 @click.argument('argument2', nargs=1, required=False)
 @click.option('--paths-to-mutate', type=click.STRING)
@@ -115,7 +144,74 @@ DEFAULT_RUNNER = 'python -m pytest -x --assert=plain'
     post_mutation=None,
     use_patch_file=None,
 )
-def climain(command, argument, argument2, paths_to_mutate, disable_mutation_types, enable_mutation_types,
+def run(argument, argument2, paths_to_mutate, disable_mutation_types, enable_mutation_types,
+        backup, runner, tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage, 
+        dict_synonyms, cache_only, version, suspicious_policy, untested_policy, pre_mutation, 
+        post_mutation, use_patch_file, paths_to_exclude, simple_output, no_progress):
+    """
+commands:\n
+    run [mutation id]\n
+        Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.\n
+    results\n
+        Print the results.\n
+    result-ids survived (or any other of: killed,timeout,suspicious,skipped,untested)\n
+        Print the IDs of the specified mutant classes (separated by spaces).\n
+    apply [mutation id]\n
+        Apply a mutation on disk.\n
+    show [mutation id]\n
+        Show a mutation diff.\n
+    show [path to file]\n
+        Show all mutation diffs for this file.\n
+    junitxml\n
+        Show a mutation diff with junitxml format.
+    """
+    if test_time_base is None:  # click sets the default=0.0 to None
+        test_time_base = 0.0
+    if test_time_multiplier is None:  # click sets the default=0.0 to None
+        test_time_multiplier = 0.0
+    sys.exit(main("run", argument, argument2, paths_to_mutate, disable_mutation_types, 
+                  enable_mutation_types, backup, runner,
+                  tests_dir, test_time_multiplier, test_time_base,
+                  swallow_output, use_coverage, dict_synonyms, cache_only,
+                  version, suspicious_policy, untested_policy, pre_mutation,
+                  post_mutation, use_patch_file, paths_to_exclude, simple_output,
+                  no_progress))
+
+
+@climain.command(context_settings=dict(help_option_names=['-h', '--help']))
+@click.argument('argument', nargs=1, required=False)
+@click.argument('argument2', nargs=1, required=False)
+@click.option('--paths-to-mutate', type=click.STRING)
+@click.option('--disable-mutation-types', type=click.STRING, help='Skip the given types of mutations.')
+@click.option('--enable-mutation-types', type=click.STRING, help='Only perform given types of mutations.')
+@click.option('--paths-to-exclude', type=click.STRING)
+@click.option('--backup/--no-backup', default=False)
+@click.option('--runner')
+@click.option('--use-coverage', is_flag=True, default=False)
+@click.option('--use-patch-file', help='Only mutate lines added/changed in the given patch file')
+@click.option('--tests-dir')
+@click.option('-m', '--test-time-multiplier', default=2.0, type=float)
+@click.option('-b', '--test-time-base', default=0.0, type=float)
+@click.option('-s', '--swallow-output', help='turn off output capture', is_flag=True)
+@click.option('--dict-synonyms')
+@click.option('--cache-only', is_flag=True, default=False)
+@click.option('--version', is_flag=True, default=False)
+@click.option('--suspicious-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
+@click.option('--untested-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
+@click.option('--pre-mutation')
+@click.option('--post-mutation')
+@click.option('--simple-output', is_flag=True, default=False, help="Swap emojis in mutmut output to plain text alternatives.")
+@click.option('--no-progress', is_flag=True, default=False, help="Disable real-time progress indicator")
+@config_from_setup_cfg(
+    dict_synonyms='',
+    paths_to_exclude='',
+    runner=DEFAULT_RUNNER,
+    tests_dir='tests/:test/',
+    pre_mutation=None,
+    post_mutation=None,
+    use_patch_file=None,
+)
+def results(argument, argument2, paths_to_mutate, disable_mutation_types, enable_mutation_types,
             backup, runner, tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage, 
             dict_synonyms, cache_only, version, suspicious_policy, untested_policy, pre_mutation, 
             post_mutation, use_patch_file, paths_to_exclude, simple_output, no_progress):
@@ -140,7 +236,342 @@ commands:\n
         test_time_base = 0.0
     if test_time_multiplier is None:  # click sets the default=0.0 to None
         test_time_multiplier = 0.0
-    sys.exit(main(command, argument, argument2, paths_to_mutate, disable_mutation_types, 
+    sys.exit(main("results", argument, argument2, paths_to_mutate, disable_mutation_types, 
+                  enable_mutation_types, backup, runner,
+                  tests_dir, test_time_multiplier, test_time_base,
+                  swallow_output, use_coverage, dict_synonyms, cache_only,
+                  version, suspicious_policy, untested_policy, pre_mutation,
+                  post_mutation, use_patch_file, paths_to_exclude, simple_output,
+                  no_progress))
+
+
+@climain.command(context_settings=dict(help_option_names=['-h', '--help']))
+@click.argument('argument', nargs=1, required=False)
+@click.argument('argument2', nargs=1, required=False)
+@click.option('--paths-to-mutate', type=click.STRING)
+@click.option('--disable-mutation-types', type=click.STRING, help='Skip the given types of mutations.')
+@click.option('--enable-mutation-types', type=click.STRING, help='Only perform given types of mutations.')
+@click.option('--paths-to-exclude', type=click.STRING)
+@click.option('--backup/--no-backup', default=False)
+@click.option('--runner')
+@click.option('--use-coverage', is_flag=True, default=False)
+@click.option('--use-patch-file', help='Only mutate lines added/changed in the given patch file')
+@click.option('--tests-dir')
+@click.option('-m', '--test-time-multiplier', default=2.0, type=float)
+@click.option('-b', '--test-time-base', default=0.0, type=float)
+@click.option('-s', '--swallow-output', help='turn off output capture', is_flag=True)
+@click.option('--dict-synonyms')
+@click.option('--cache-only', is_flag=True, default=False)
+@click.option('--version', is_flag=True, default=False)
+@click.option('--suspicious-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
+@click.option('--untested-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
+@click.option('--pre-mutation')
+@click.option('--post-mutation')
+@click.option('--simple-output', is_flag=True, default=False, help="Swap emojis in mutmut output to plain text alternatives.")
+@click.option('--no-progress', is_flag=True, default=False, help="Disable real-time progress indicator")
+@config_from_setup_cfg(
+    dict_synonyms='',
+    paths_to_exclude='',
+    runner=DEFAULT_RUNNER,
+    tests_dir='tests/:test/',
+    pre_mutation=None,
+    post_mutation=None,
+    use_patch_file=None,
+)
+def result_ids(argument, argument2, paths_to_mutate, disable_mutation_types, enable_mutation_types,
+        backup, runner, tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage, 
+        dict_synonyms, cache_only, version, suspicious_policy, untested_policy, pre_mutation, 
+        post_mutation, use_patch_file, paths_to_exclude, simple_output, no_progress):
+    """
+commands:\n
+    run [mutation id]\n
+        Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.\n
+    results\n
+        Print the results.\n
+    result-ids survived (or any other of: killed,timeout,suspicious,skipped,untested)\n
+        Print the IDs of the specified mutant classes (separated by spaces).\n
+    apply [mutation id]\n
+        Apply a mutation on disk.\n
+    show [mutation id]\n
+        Show a mutation diff.\n
+    show [path to file]\n
+        Show all mutation diffs for this file.\n
+    junitxml\n
+        Show a mutation diff with junitxml format.
+    """
+    if test_time_base is None:  # click sets the default=0.0 to None
+        test_time_base = 0.0
+    if test_time_multiplier is None:  # click sets the default=0.0 to None
+        test_time_multiplier = 0.0
+    sys.exit(main("result-ids", argument, argument2, paths_to_mutate, disable_mutation_types, 
+                  enable_mutation_types, backup, runner,
+                  tests_dir, test_time_multiplier, test_time_base,
+                  swallow_output, use_coverage, dict_synonyms, cache_only,
+                  version, suspicious_policy, untested_policy, pre_mutation,
+                  post_mutation, use_patch_file, paths_to_exclude, simple_output,
+                  no_progress))
+
+
+@climain.command(context_settings=dict(help_option_names=['-h', '--help']))
+@click.argument('argument', nargs=1, required=False)
+@click.argument('argument2', nargs=1, required=False)
+@click.option('--paths-to-mutate', type=click.STRING)
+@click.option('--disable-mutation-types', type=click.STRING, help='Skip the given types of mutations.')
+@click.option('--enable-mutation-types', type=click.STRING, help='Only perform given types of mutations.')
+@click.option('--paths-to-exclude', type=click.STRING)
+@click.option('--backup/--no-backup', default=False)
+@click.option('--runner')
+@click.option('--use-coverage', is_flag=True, default=False)
+@click.option('--use-patch-file', help='Only mutate lines added/changed in the given patch file')
+@click.option('--tests-dir')
+@click.option('-m', '--test-time-multiplier', default=2.0, type=float)
+@click.option('-b', '--test-time-base', default=0.0, type=float)
+@click.option('-s', '--swallow-output', help='turn off output capture', is_flag=True)
+@click.option('--dict-synonyms')
+@click.option('--cache-only', is_flag=True, default=False)
+@click.option('--version', is_flag=True, default=False)
+@click.option('--suspicious-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
+@click.option('--untested-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
+@click.option('--pre-mutation')
+@click.option('--post-mutation')
+@click.option('--simple-output', is_flag=True, default=False, help="Swap emojis in mutmut output to plain text alternatives.")
+@click.option('--no-progress', is_flag=True, default=False, help="Disable real-time progress indicator")
+@config_from_setup_cfg(
+    dict_synonyms='',
+    paths_to_exclude='',
+    runner=DEFAULT_RUNNER,
+    tests_dir='tests/:test/',
+    pre_mutation=None,
+    post_mutation=None,
+    use_patch_file=None,
+)
+def apply(argument, argument2, paths_to_mutate, disable_mutation_types, enable_mutation_types,
+        backup, runner, tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage, 
+        dict_synonyms, cache_only, version, suspicious_policy, untested_policy, pre_mutation, 
+        post_mutation, use_patch_file, paths_to_exclude, simple_output, no_progress):
+    """
+commands:\n
+    run [mutation id]\n
+        Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.\n
+    results\n
+        Print the results.\n
+    result-ids survived (or any other of: killed,timeout,suspicious,skipped,untested)\n
+        Print the IDs of the specified mutant classes (separated by spaces).\n
+    apply [mutation id]\n
+        Apply a mutation on disk.\n
+    show [mutation id]\n
+        Show a mutation diff.\n
+    show [path to file]\n
+        Show all mutation diffs for this file.\n
+    junitxml\n
+        Show a mutation diff with junitxml format.
+    """
+    if test_time_base is None:  # click sets the default=0.0 to None
+        test_time_base = 0.0
+    if test_time_multiplier is None:  # click sets the default=0.0 to None
+        test_time_multiplier = 0.0
+    sys.exit(main("apply", argument, argument2, paths_to_mutate, disable_mutation_types, 
+                  enable_mutation_types, backup, runner,
+                  tests_dir, test_time_multiplier, test_time_base,
+                  swallow_output, use_coverage, dict_synonyms, cache_only,
+                  version, suspicious_policy, untested_policy, pre_mutation,
+                  post_mutation, use_patch_file, paths_to_exclude, simple_output,
+                  no_progress))
+
+
+@climain.command(context_settings=dict(help_option_names=['-h', '--help']))
+@click.argument('argument', nargs=1, required=False)
+@click.argument('argument2', nargs=1, required=False)
+@click.option('--paths-to-mutate', type=click.STRING)
+@click.option('--disable-mutation-types', type=click.STRING, help='Skip the given types of mutations.')
+@click.option('--enable-mutation-types', type=click.STRING, help='Only perform given types of mutations.')
+@click.option('--paths-to-exclude', type=click.STRING)
+@click.option('--backup/--no-backup', default=False)
+@click.option('--runner')
+@click.option('--use-coverage', is_flag=True, default=False)
+@click.option('--use-patch-file', help='Only mutate lines added/changed in the given patch file')
+@click.option('--tests-dir')
+@click.option('-m', '--test-time-multiplier', default=2.0, type=float)
+@click.option('-b', '--test-time-base', default=0.0, type=float)
+@click.option('-s', '--swallow-output', help='turn off output capture', is_flag=True)
+@click.option('--dict-synonyms')
+@click.option('--cache-only', is_flag=True, default=False)
+@click.option('--version', is_flag=True, default=False)
+@click.option('--suspicious-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
+@click.option('--untested-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
+@click.option('--pre-mutation')
+@click.option('--post-mutation')
+@click.option('--simple-output', is_flag=True, default=False, help="Swap emojis in mutmut output to plain text alternatives.")
+@click.option('--no-progress', is_flag=True, default=False, help="Disable real-time progress indicator")
+@config_from_setup_cfg(
+    dict_synonyms='',
+    paths_to_exclude='',
+    runner=DEFAULT_RUNNER,
+    tests_dir='tests/:test/',
+    pre_mutation=None,
+    post_mutation=None,
+    use_patch_file=None,
+)
+def show(argument, argument2, paths_to_mutate, disable_mutation_types, enable_mutation_types,
+        backup, runner, tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage, 
+        dict_synonyms, cache_only, version, suspicious_policy, untested_policy, pre_mutation, 
+        post_mutation, use_patch_file, paths_to_exclude, simple_output, no_progress):
+    """
+commands:\n
+    run [mutation id]\n
+        Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.\n
+    results\n
+        Print the results.\n
+    result-ids survived (or any other of: killed,timeout,suspicious,skipped,untested)\n
+        Print the IDs of the specified mutant classes (separated by spaces).\n
+    apply [mutation id]\n
+        Apply a mutation on disk.\n
+    show [mutation id]\n
+        Show a mutation diff.\n
+    show [path to file]\n
+        Show all mutation diffs for this file.\n
+    junitxml\n
+        Show a mutation diff with junitxml format.
+    """
+    if test_time_base is None:  # click sets the default=0.0 to None
+        test_time_base = 0.0
+    if test_time_multiplier is None:  # click sets the default=0.0 to None
+        test_time_multiplier = 0.0
+    sys.exit(main("show", argument, argument2, paths_to_mutate, disable_mutation_types, 
+                  enable_mutation_types, backup, runner,
+                  tests_dir, test_time_multiplier, test_time_base,
+                  swallow_output, use_coverage, dict_synonyms, cache_only,
+                  version, suspicious_policy, untested_policy, pre_mutation,
+                  post_mutation, use_patch_file, paths_to_exclude, simple_output,
+                  no_progress))
+
+
+@climain.command(context_settings=dict(help_option_names=['-h', '--help']))
+@click.argument('argument', nargs=1, required=False)
+@click.argument('argument2', nargs=1, required=False)
+@click.option('--paths-to-mutate', type=click.STRING)
+@click.option('--disable-mutation-types', type=click.STRING, help='Skip the given types of mutations.')
+@click.option('--enable-mutation-types', type=click.STRING, help='Only perform given types of mutations.')
+@click.option('--paths-to-exclude', type=click.STRING)
+@click.option('--backup/--no-backup', default=False)
+@click.option('--runner')
+@click.option('--use-coverage', is_flag=True, default=False)
+@click.option('--use-patch-file', help='Only mutate lines added/changed in the given patch file')
+@click.option('--tests-dir')
+@click.option('-m', '--test-time-multiplier', default=2.0, type=float)
+@click.option('-b', '--test-time-base', default=0.0, type=float)
+@click.option('-s', '--swallow-output', help='turn off output capture', is_flag=True)
+@click.option('--dict-synonyms')
+@click.option('--cache-only', is_flag=True, default=False)
+@click.option('--version', is_flag=True, default=False)
+@click.option('--suspicious-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
+@click.option('--untested-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
+@click.option('--pre-mutation')
+@click.option('--post-mutation')
+@click.option('--simple-output', is_flag=True, default=False, help="Swap emojis in mutmut output to plain text alternatives.")
+@click.option('--no-progress', is_flag=True, default=False, help="Disable real-time progress indicator")
+@config_from_setup_cfg(
+    dict_synonyms='',
+    paths_to_exclude='',
+    runner=DEFAULT_RUNNER,
+    tests_dir='tests/:test/',
+    pre_mutation=None,
+    post_mutation=None,
+    use_patch_file=None,
+)
+def junitxml(argument, argument2, paths_to_mutate, disable_mutation_types, enable_mutation_types,
+            backup, runner, tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage, 
+            dict_synonyms, cache_only, version, suspicious_policy, untested_policy, pre_mutation, 
+            post_mutation, use_patch_file, paths_to_exclude, simple_output, no_progress):
+    """
+commands:\n
+    run [mutation id]\n
+        Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.\n
+    results\n
+        Print the results.\n
+    result-ids survived (or any other of: killed,timeout,suspicious,skipped,untested)\n
+        Print the IDs of the specified mutant classes (separated by spaces).\n
+    apply [mutation id]\n
+        Apply a mutation on disk.\n
+    show [mutation id]\n
+        Show a mutation diff.\n
+    show [path to file]\n
+        Show all mutation diffs for this file.\n
+    junitxml\n
+        Show a mutation diff with junitxml format.
+    """
+    if test_time_base is None:  # click sets the default=0.0 to None
+        test_time_base = 0.0
+    if test_time_multiplier is None:  # click sets the default=0.0 to None
+        test_time_multiplier = 0.0
+    sys.exit(main("junitxml", argument, argument2, paths_to_mutate, disable_mutation_types, 
+                  enable_mutation_types, backup, runner,
+                  tests_dir, test_time_multiplier, test_time_base,
+                  swallow_output, use_coverage, dict_synonyms, cache_only,
+                  version, suspicious_policy, untested_policy, pre_mutation,
+                  post_mutation, use_patch_file, paths_to_exclude, simple_output,
+                  no_progress))
+
+
+@climain.command(context_settings=dict(help_option_names=['-h', '--help']))
+@click.argument('argument', nargs=1, required=False)
+@click.argument('argument2', nargs=1, required=False)
+@click.option('--paths-to-mutate', type=click.STRING)
+@click.option('--disable-mutation-types', type=click.STRING, help='Skip the given types of mutations.')
+@click.option('--enable-mutation-types', type=click.STRING, help='Only perform given types of mutations.')
+@click.option('--paths-to-exclude', type=click.STRING)
+@click.option('--backup/--no-backup', default=False)
+@click.option('--runner')
+@click.option('--use-coverage', is_flag=True, default=False)
+@click.option('--use-patch-file', help='Only mutate lines added/changed in the given patch file')
+@click.option('--tests-dir')
+@click.option('-m', '--test-time-multiplier', default=2.0, type=float)
+@click.option('-b', '--test-time-base', default=0.0, type=float)
+@click.option('-s', '--swallow-output', help='turn off output capture', is_flag=True)
+@click.option('--dict-synonyms')
+@click.option('--cache-only', is_flag=True, default=False)
+@click.option('--version', is_flag=True, default=False)
+@click.option('--suspicious-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
+@click.option('--untested-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
+@click.option('--pre-mutation')
+@click.option('--post-mutation')
+@click.option('--simple-output', is_flag=True, default=False, help="Swap emojis in mutmut output to plain text alternatives.")
+@click.option('--no-progress', is_flag=True, default=False, help="Disable real-time progress indicator")
+@config_from_setup_cfg(
+    dict_synonyms='',
+    paths_to_exclude='',
+    runner=DEFAULT_RUNNER,
+    tests_dir='tests/:test/',
+    pre_mutation=None,
+    post_mutation=None,
+    use_patch_file=None,
+)
+def html(argument, argument2, paths_to_mutate, disable_mutation_types, enable_mutation_types,
+        backup, runner, tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage, 
+        dict_synonyms, cache_only, version, suspicious_policy, untested_policy, pre_mutation, 
+        post_mutation, use_patch_file, paths_to_exclude, simple_output, no_progress):
+    """
+commands:\n
+    run [mutation id]\n
+        Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.\n
+    results\n
+        Print the results.\n
+    result-ids survived (or any other of: killed,timeout,suspicious,skipped,untested)\n
+        Print the IDs of the specified mutant classes (separated by spaces).\n
+    apply [mutation id]\n
+        Apply a mutation on disk.\n
+    show [mutation id]\n
+        Show a mutation diff.\n
+    show [path to file]\n
+        Show all mutation diffs for this file.\n
+    junitxml\n
+        Show a mutation diff with junitxml format.
+    """
+    if test_time_base is None:  # click sets the default=0.0 to None
+        test_time_base = 0.0
+    if test_time_multiplier is None:  # click sets the default=0.0 to None
+        test_time_multiplier = 0.0
+    sys.exit(main("html", argument, argument2, paths_to_mutate, disable_mutation_types, 
                   enable_mutation_types, backup, runner,
                   tests_dir, test_time_multiplier, test_time_base,
                   swallow_output, use_coverage, dict_synonyms, cache_only,

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -82,31 +82,16 @@ null_out = open(os.devnull, 'w')
 DEFAULT_RUNNER = 'python -m pytest -x --assert=plain'
 
 @click.group(context_settings=dict(help_option_names=['-h', '--help']))
-@click.option('--version', is_flag=True, default=False)
-def climain(version):
+def climain():
     """
-commands:\n
-    run [mutation id]\n
-        Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.\n
-    results\n
-        Print the results.\n
-    result-ids survived (or any other of: killed,timeout,suspicious,skipped,untested)\n
-        Print the IDs of the specified mutant classes (separated by spaces).\n
-    apply [mutation id]\n
-        Apply a mutation on disk.\n
-    show [mutation id]\n
-        Show a mutation diff.\n
-    show [path to file]\n
-        Show all mutation diffs for this file.\n
-    junitxml\n
-        Show a mutation diff with junitxml format.
+    Mutation testing system for Python.
     """
     pass
 
 
 @climain.command()
 def version():
-    """Show the version and exit"""
+    """Show the version and exit."""
     print("mutmut version {}".format(__version__))
     sys.exit(0)
 
@@ -168,16 +153,16 @@ def results():
 
 
 @climain.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.argument('argument', nargs=1, required=False)
-def result_ids(argument):
+@click.argument('status', nargs=1, required=True)
+def result_ids(status):
     """
     Print the IDs of the specified mutant classes (separated by spaces).\n
     result-ids survived (or any other of: killed,timeout,suspicious,skipped,untested)\n
     """
-    if not argument or argument not in MUTANT_STATUSES:
+    if not status or status not in MUTANT_STATUSES:
         raise click.BadArgumentUsage(f'The result-ids command needs a status class of mutants '
-                                     f'(one of : {set(MUTANT_STATUSES.keys())}) but was {argument}')
-    print_result_ids_cache(argument)
+                                     f'(one of : {set(MUTANT_STATUSES.keys())}) but was {status}')
+    print_result_ids_cache(status)
     sys.exit(0)
 
 
@@ -190,8 +175,7 @@ def result_ids(argument):
 )
 def apply(mutation_id, backup, dict_synonyms):
     """
-    apply [mutation id]\n
-        Apply a mutation on disk.\n
+    Apply a mutation on disk.
     """
     do_apply(mutation_id, dict_synonyms, backup)
     sys.exit(0)
@@ -206,8 +190,7 @@ def apply(mutation_id, backup, dict_synonyms):
 )
 def show(id_or_file, only_filenames, dict_synonyms):
     """
-    show [mutation id or filename]\n
-        Show a mutation diff.\n
+    Show a mutation diff.
     """
     if not id_or_file:
         print_result_cache()
@@ -234,8 +217,7 @@ def show(id_or_file, only_filenames, dict_synonyms):
 )
 def junitxml(dict_synonyms, suspicious_policy, untested_policy):
     """
-    junitxml\n
-        Show a mutation diff with junitxml format.
+    Show a mutation diff with junitxml format.
     """
     print_result_cache_junitxml(dict_synonyms, suspicious_policy, untested_policy)
     sys.exit(0)

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -346,70 +346,19 @@ def result_ids(argument):
 
 
 @climain.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.argument('argument', nargs=1, required=False)
-@click.argument('argument2', nargs=1, required=False)
-@click.option('--paths-to-mutate', type=click.STRING)
-@click.option('--disable-mutation-types', type=click.STRING, help='Skip the given types of mutations.')
-@click.option('--enable-mutation-types', type=click.STRING, help='Only perform given types of mutations.')
-@click.option('--paths-to-exclude', type=click.STRING)
+@click.argument('mutation-id', nargs=1, required=True)
 @click.option('--backup/--no-backup', default=False)
-@click.option('--runner')
-@click.option('--use-coverage', is_flag=True, default=False)
-@click.option('--use-patch-file', help='Only mutate lines added/changed in the given patch file')
-@click.option('--tests-dir')
-@click.option('-m', '--test-time-multiplier', default=2.0, type=float)
-@click.option('-b', '--test-time-base', default=0.0, type=float)
-@click.option('-s', '--swallow-output', help='turn off output capture', is_flag=True)
 @click.option('--dict-synonyms')
-@click.option('--cache-only', is_flag=True, default=False)
-@click.option('--version', is_flag=True, default=False)
-@click.option('--suspicious-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
-@click.option('--untested-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
-@click.option('--pre-mutation')
-@click.option('--post-mutation')
-@click.option('--simple-output', is_flag=True, default=False, help="Swap emojis in mutmut output to plain text alternatives.")
-@click.option('--no-progress', is_flag=True, default=False, help="Disable real-time progress indicator")
 @config_from_setup_cfg(
     dict_synonyms='',
-    paths_to_exclude='',
-    runner=DEFAULT_RUNNER,
-    tests_dir='tests/:test/',
-    pre_mutation=None,
-    post_mutation=None,
-    use_patch_file=None,
 )
-def apply(argument, argument2, paths_to_mutate, disable_mutation_types, enable_mutation_types,
-        backup, runner, tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage, 
-        dict_synonyms, cache_only, version, suspicious_policy, untested_policy, pre_mutation, 
-        post_mutation, use_patch_file, paths_to_exclude, simple_output, no_progress):
+def apply(mutation_id, backup, dict_synonyms):
     """
-commands:\n
-    run [mutation id]\n
-        Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.\n
-    results\n
-        Print the results.\n
-    result-ids survived (or any other of: killed,timeout,suspicious,skipped,untested)\n
-        Print the IDs of the specified mutant classes (separated by spaces).\n
     apply [mutation id]\n
         Apply a mutation on disk.\n
-    show [mutation id]\n
-        Show a mutation diff.\n
-    show [path to file]\n
-        Show all mutation diffs for this file.\n
-    junitxml\n
-        Show a mutation diff with junitxml format.
     """
-    if test_time_base is None:  # click sets the default=0.0 to None
-        test_time_base = 0.0
-    if test_time_multiplier is None:  # click sets the default=0.0 to None
-        test_time_multiplier = 0.0
-    sys.exit(main("apply", argument, argument2, paths_to_mutate, disable_mutation_types, 
-                  enable_mutation_types, backup, runner,
-                  tests_dir, test_time_multiplier, test_time_base,
-                  swallow_output, use_coverage, dict_synonyms, cache_only,
-                  version, suspicious_policy, untested_policy, pre_mutation,
-                  post_mutation, use_patch_file, paths_to_exclude, simple_output,
-                  no_progress))
+    do_apply(mutation_id, dict_synonyms, backup)
+    sys.exit(0)
 
 
 @climain.command(context_settings=dict(help_option_names=['-h', '--help']))

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -406,70 +406,16 @@ def junitxml(dict_synonyms, suspicious_policy, untested_policy):
 
 
 @climain.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.argument('argument', nargs=1, required=False)
-@click.argument('argument2', nargs=1, required=False)
-@click.option('--paths-to-mutate', type=click.STRING)
-@click.option('--disable-mutation-types', type=click.STRING, help='Skip the given types of mutations.')
-@click.option('--enable-mutation-types', type=click.STRING, help='Only perform given types of mutations.')
-@click.option('--paths-to-exclude', type=click.STRING)
-@click.option('--backup/--no-backup', default=False)
-@click.option('--runner')
-@click.option('--use-coverage', is_flag=True, default=False)
-@click.option('--use-patch-file', help='Only mutate lines added/changed in the given patch file')
-@click.option('--tests-dir')
-@click.option('-m', '--test-time-multiplier', default=2.0, type=float)
-@click.option('-b', '--test-time-base', default=0.0, type=float)
-@click.option('-s', '--swallow-output', help='turn off output capture', is_flag=True)
 @click.option('--dict-synonyms')
-@click.option('--cache-only', is_flag=True, default=False)
-@click.option('--version', is_flag=True, default=False)
-@click.option('--suspicious-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
-@click.option('--untested-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
-@click.option('--pre-mutation')
-@click.option('--post-mutation')
-@click.option('--simple-output', is_flag=True, default=False, help="Swap emojis in mutmut output to plain text alternatives.")
-@click.option('--no-progress', is_flag=True, default=False, help="Disable real-time progress indicator")
 @config_from_setup_cfg(
     dict_synonyms='',
-    paths_to_exclude='',
-    runner=DEFAULT_RUNNER,
-    tests_dir='tests/:test/',
-    pre_mutation=None,
-    post_mutation=None,
-    use_patch_file=None,
 )
-def html(argument, argument2, paths_to_mutate, disable_mutation_types, enable_mutation_types,
-        backup, runner, tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage, 
-        dict_synonyms, cache_only, version, suspicious_policy, untested_policy, pre_mutation, 
-        post_mutation, use_patch_file, paths_to_exclude, simple_output, no_progress):
+def html(dict_synonyms):
     """
-commands:\n
-    run [mutation id]\n
-        Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.\n
-    results\n
-        Print the results.\n
-    result-ids survived (or any other of: killed,timeout,suspicious,skipped,untested)\n
-        Print the IDs of the specified mutant classes (separated by spaces).\n
-    apply [mutation id]\n
-        Apply a mutation on disk.\n
-    show [mutation id]\n
-        Show a mutation diff.\n
-    show [path to file]\n
-        Show all mutation diffs for this file.\n
-    junitxml\n
-        Show a mutation diff with junitxml format.
+    Generate a HTML report of surviving mutants.
     """
-    if test_time_base is None:  # click sets the default=0.0 to None
-        test_time_base = 0.0
-    if test_time_multiplier is None:  # click sets the default=0.0 to None
-        test_time_multiplier = 0.0
-    sys.exit(main("html", argument, argument2, paths_to_mutate, disable_mutation_types, 
-                  enable_mutation_types, backup, runner,
-                  tests_dir, test_time_multiplier, test_time_base,
-                  swallow_output, use_coverage, dict_synonyms, cache_only,
-                  version, suspicious_policy, untested_policy, pre_mutation,
-                  post_mutation, use_patch_file, paths_to_exclude, simple_output,
-                  no_progress))
+    create_html_report(dict_synonyms)
+    sys.exit(0)
 
 
 def main(command, argument, argument2, paths_to_mutate, disable_mutation_types, 

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -333,69 +333,16 @@ def results():
 
 @climain.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.argument('argument', nargs=1, required=False)
-@click.argument('argument2', nargs=1, required=False)
-@click.option('--paths-to-mutate', type=click.STRING)
-@click.option('--disable-mutation-types', type=click.STRING, help='Skip the given types of mutations.')
-@click.option('--enable-mutation-types', type=click.STRING, help='Only perform given types of mutations.')
-@click.option('--paths-to-exclude', type=click.STRING)
-@click.option('--backup/--no-backup', default=False)
-@click.option('--runner')
-@click.option('--use-coverage', is_flag=True, default=False)
-@click.option('--use-patch-file', help='Only mutate lines added/changed in the given patch file')
-@click.option('--tests-dir')
-@click.option('-m', '--test-time-multiplier', default=2.0, type=float)
-@click.option('-b', '--test-time-base', default=0.0, type=float)
-@click.option('-s', '--swallow-output', help='turn off output capture', is_flag=True)
-@click.option('--dict-synonyms')
-@click.option('--cache-only', is_flag=True, default=False)
-@click.option('--version', is_flag=True, default=False)
-@click.option('--suspicious-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
-@click.option('--untested-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
-@click.option('--pre-mutation')
-@click.option('--post-mutation')
-@click.option('--simple-output', is_flag=True, default=False, help="Swap emojis in mutmut output to plain text alternatives.")
-@click.option('--no-progress', is_flag=True, default=False, help="Disable real-time progress indicator")
-@config_from_setup_cfg(
-    dict_synonyms='',
-    paths_to_exclude='',
-    runner=DEFAULT_RUNNER,
-    tests_dir='tests/:test/',
-    pre_mutation=None,
-    post_mutation=None,
-    use_patch_file=None,
-)
-def result_ids(argument, argument2, paths_to_mutate, disable_mutation_types, enable_mutation_types,
-        backup, runner, tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage, 
-        dict_synonyms, cache_only, version, suspicious_policy, untested_policy, pre_mutation, 
-        post_mutation, use_patch_file, paths_to_exclude, simple_output, no_progress):
+def result_ids(argument):
     """
-commands:\n
-    run [mutation id]\n
-        Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.\n
-    results\n
-        Print the results.\n
+    Print the IDs of the specified mutant classes (separated by spaces).\n
     result-ids survived (or any other of: killed,timeout,suspicious,skipped,untested)\n
-        Print the IDs of the specified mutant classes (separated by spaces).\n
-    apply [mutation id]\n
-        Apply a mutation on disk.\n
-    show [mutation id]\n
-        Show a mutation diff.\n
-    show [path to file]\n
-        Show all mutation diffs for this file.\n
-    junitxml\n
-        Show a mutation diff with junitxml format.
     """
-    if test_time_base is None:  # click sets the default=0.0 to None
-        test_time_base = 0.0
-    if test_time_multiplier is None:  # click sets the default=0.0 to None
-        test_time_multiplier = 0.0
-    sys.exit(main("result-ids", argument, argument2, paths_to_mutate, disable_mutation_types, 
-                  enable_mutation_types, backup, runner,
-                  tests_dir, test_time_multiplier, test_time_base,
-                  swallow_output, use_coverage, dict_synonyms, cache_only,
-                  version, suspicious_policy, untested_policy, pre_mutation,
-                  post_mutation, use_patch_file, paths_to_exclude, simple_output,
-                  no_progress))
+    if not argument or argument not in MUTANT_STATUSES:
+        raise click.BadArgumentUsage(f'The result-ids command needs a status class of mutants '
+                                     f'(one of : {set(MUTANT_STATUSES.keys())}) but was {argument}')
+    print_result_ids_cache(argument)
+    sys.exit(0)
 
 
 @climain.command(context_settings=dict(help_option_names=['-h', '--help']))

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -113,7 +113,6 @@ def version():
 
 @climain.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.argument('argument', nargs=1, required=False)
-@click.argument('argument2', nargs=1, required=False)
 @click.option('--paths-to-mutate', type=click.STRING)
 @click.option('--disable-mutation-types', type=click.STRING, help='Skip the given types of mutations.')
 @click.option('--enable-mutation-types', type=click.STRING, help='Only perform given types of mutations.')
@@ -128,9 +127,6 @@ def version():
 @click.option('-s', '--swallow-output', help='turn off output capture', is_flag=True)
 @click.option('--dict-synonyms')
 @click.option('--cache-only', is_flag=True, default=False)
-@click.option('--version', is_flag=True, default=False)
-@click.option('--suspicious-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
-@click.option('--untested-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
 @click.option('--pre-mutation')
 @click.option('--post-mutation')
 @click.option('--simple-output', is_flag=True, default=False, help="Swap emojis in mutmut output to plain text alternatives.")
@@ -144,38 +140,186 @@ def version():
     post_mutation=None,
     use_patch_file=None,
 )
-def run(argument, argument2, paths_to_mutate, disable_mutation_types, enable_mutation_types,
-        backup, runner, tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage, 
-        dict_synonyms, cache_only, version, suspicious_policy, untested_policy, pre_mutation, 
-        post_mutation, use_patch_file, paths_to_exclude, simple_output, no_progress):
+def run(argument, paths_to_mutate, disable_mutation_types, enable_mutation_types, backup, runner,
+        tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage, 
+        dict_synonyms, cache_only, pre_mutation, post_mutation, use_patch_file, paths_to_exclude,
+        simple_output, no_progress):
     """
-commands:\n
-    run [mutation id]\n
-        Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.\n
-    results\n
-        Print the results.\n
-    result-ids survived (or any other of: killed,timeout,suspicious,skipped,untested)\n
-        Print the IDs of the specified mutant classes (separated by spaces).\n
-    apply [mutation id]\n
-        Apply a mutation on disk.\n
-    show [mutation id]\n
-        Show a mutation diff.\n
-    show [path to file]\n
-        Show all mutation diffs for this file.\n
-    junitxml\n
-        Show a mutation diff with junitxml format.
+    Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.
     """
     if test_time_base is None:  # click sets the default=0.0 to None
         test_time_base = 0.0
     if test_time_multiplier is None:  # click sets the default=0.0 to None
         test_time_multiplier = 0.0
-    sys.exit(main("run", argument, argument2, paths_to_mutate, disable_mutation_types, 
-                  enable_mutation_types, backup, runner,
-                  tests_dir, test_time_multiplier, test_time_base,
-                  swallow_output, use_coverage, dict_synonyms, cache_only,
-                  version, suspicious_policy, untested_policy, pre_mutation,
-                  post_mutation, use_patch_file, paths_to_exclude, simple_output,
-                  no_progress))
+
+    if use_coverage and use_patch_file:
+        raise click.BadArgumentUsage("You can't combine --use-coverage and --use-patch")
+
+    if disable_mutation_types and enable_mutation_types:
+        raise click.BadArgumentUsage("You can't combine --disable-mutation-types and --enable-mutation-types")
+    if enable_mutation_types:
+        mutation_types_to_apply = set(mtype.strip() for mtype in enable_mutation_types.split(","))
+        invalid_types = [mtype for mtype in mutation_types_to_apply if mtype not in mutations_by_type]
+    elif disable_mutation_types:
+        mutation_types_to_apply = set(mutations_by_type.keys()) - set(mtype.strip() for mtype in disable_mutation_types.split(","))
+        invalid_types = [mtype for mtype in disable_mutation_types.split(",") if mtype not in mutations_by_type]
+    else:
+        mutation_types_to_apply = set(mutations_by_type.keys())
+        invalid_types = None
+    if invalid_types:
+        raise click.BadArgumentUsage(f"The following are not valid mutation types: {', '.join(sorted(invalid_types))}. Valid mutation types are: {', '.join(mutations_by_type.keys())}")
+
+    dict_synonyms = [x.strip() for x in dict_synonyms.split(',')]
+
+    if use_coverage and not exists('.coverage'):
+        raise FileNotFoundError('No .coverage file found. You must generate a coverage file to use this feature.')
+
+    if paths_to_mutate is None:
+        paths_to_mutate = guess_paths_to_mutate()
+
+    Pattern = namedtuple('Pattern', 'char pattern')
+
+    def get_pattern(char):
+        return re.compile(fr"^(\w+)({char}\s*\w+)*$")
+
+    def get_separation_char(input_string, patterns):
+        for p in patterns:
+            if p.pattern.match(input_string):
+                return p.char
+
+    patterns = [Pattern(',', get_pattern(',')),
+                Pattern(':', get_pattern(':'))]
+
+    mut_paths_sep = get_separation_char(paths_to_mutate, patterns)
+    tests_dir_sep = get_separation_char(tests_dir, patterns)
+
+    if not isinstance(paths_to_mutate, (list, tuple)):
+        paths_to_mutate = [x.strip() for x in paths_to_mutate.split(mut_paths_sep)]
+
+    if not paths_to_mutate:
+        raise click.BadOptionUsage('--paths-to-mutate', 'You must specify a list of paths to mutate. Either as a command line argument, or by setting paths_to_mutate under the section [mutmut] in setup.cfg')
+
+    tests_dirs = []
+    for p in tests_dir.split(tests_dir_sep):
+        tests_dirs.extend(glob(p, recursive=True))
+
+    for p in paths_to_mutate:
+        for pt in tests_dir.split(tests_dir_sep):
+            tests_dirs.extend(glob(p + '/**/' + pt, recursive=True))
+    del tests_dir
+    current_hash_of_tests = hash_of_tests(tests_dirs)
+
+    os.environ['PYTHONDONTWRITEBYTECODE'] = '1'  # stop python from creating .pyc files
+
+    using_testmon = '--testmon' in runner
+    output_legend = {
+        "killed": "🎉",
+        "timeout": "⏰",
+        "suspicious": "🤔",
+        "survived": "🙁",
+        "skipped": "🔇",
+    }
+    if simple_output:
+        output_legend = {key: key.upper() for (key, value) in output_legend.items()}
+
+    print("""
+- Mutation testing starting -
+
+These are the steps:
+1. A full test suite run will be made to make sure we
+   can run the tests successfully and we know how long
+   it takes (to detect infinite loops for example)
+2. Mutants will be generated and checked
+
+Results are stored in .mutmut-cache.
+Print found mutants with `mutmut results`.
+
+Legend for output:
+{killed} Killed mutants.   The goal is for everything to end up in this bucket.
+{timeout} Timeout.          Test suite took 10 times as long as the baseline so were killed.
+{suspicious} Suspicious.       Tests took a long time, but not long enough to be fatal.
+{survived} Survived.         This means your tests need to be expanded.
+{skipped} Skipped.          Skipped.
+""".format(**output_legend))
+    if runner is DEFAULT_RUNNER:
+        try:
+            import pytest
+        except ImportError:
+            runner = 'python -m unittest'
+
+    baseline_time_elapsed = time_test_suite(
+        swallow_output=not swallow_output,
+        test_command=runner,
+        using_testmon=using_testmon,
+        current_hash_of_tests=current_hash_of_tests,
+    )
+
+    if hasattr(mutmut_config, 'init'):
+        mutmut_config.init()
+
+    if using_testmon:
+        copy('.testmondata', '.testmondata-initial')
+
+    # if we're running in a mode with externally whitelisted lines
+    covered_lines_by_filename = None
+    coverage_data = None
+    if use_coverage or use_patch_file:
+        covered_lines_by_filename = {}
+        if use_coverage:
+            coverage_data = read_coverage_data()
+            check_coverage_data_filepaths(coverage_data)
+        else:
+            assert use_patch_file
+            covered_lines_by_filename = read_patch_data(use_patch_file)
+
+    mutations_by_file = {}
+
+    paths_to_exclude = paths_to_exclude or ''
+    if paths_to_exclude:
+        paths_to_exclude = [path.strip() for path in paths_to_exclude.replace(',', '\n').split('\n')]
+        paths_to_exclude = [x for x in paths_to_exclude if x]
+
+    config = Config(
+        total=0,  # we'll fill this in later!
+        swallow_output=not swallow_output,
+        test_command=runner,
+        covered_lines_by_filename=covered_lines_by_filename,
+        coverage_data=coverage_data,
+        baseline_time_elapsed=baseline_time_elapsed,
+        backup=backup,
+        dict_synonyms=dict_synonyms,
+        using_testmon=using_testmon,
+        cache_only=cache_only,
+        tests_dirs=tests_dirs,
+        hash_of_tests=current_hash_of_tests,
+        test_time_multiplier=test_time_multiplier,
+        test_time_base=test_time_base,
+        pre_mutation=pre_mutation,
+        post_mutation=post_mutation,
+        paths_to_mutate=paths_to_mutate,
+        mutation_types_to_apply=mutation_types_to_apply,
+        no_progress=no_progress
+    )
+
+    parse_run_argument(argument, config, dict_synonyms, mutations_by_file, paths_to_exclude, paths_to_mutate, tests_dirs)
+
+    config.total = sum(len(mutations) for mutations in mutations_by_file.values())
+
+    print()
+    print('2. Checking mutants')
+    progress = Progress(total=config.total, output_legend=output_legend)
+
+    try:
+        run_mutation_tests(config=config, progress=progress, mutations_by_file=mutations_by_file)
+    except Exception as e:
+        traceback.print_exc()
+        sys.exit(compute_exit_code(progress, e))
+    else:
+        sys.exit(compute_exit_code(progress))
+    finally:
+        print()  # make sure we end the output with a newline
+        # Close all active multiprocessing queues to avoid hanging up the main process
+        close_active_queues()
 
 
 @climain.command(context_settings=dict(help_option_names=['-h', '--help']))

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -362,70 +362,31 @@ def apply(mutation_id, backup, dict_synonyms):
 
 
 @climain.command(context_settings=dict(help_option_names=['-h', '--help']))
-@click.argument('argument', nargs=1, required=False)
-@click.argument('argument2', nargs=1, required=False)
-@click.option('--paths-to-mutate', type=click.STRING)
-@click.option('--disable-mutation-types', type=click.STRING, help='Skip the given types of mutations.')
-@click.option('--enable-mutation-types', type=click.STRING, help='Only perform given types of mutations.')
-@click.option('--paths-to-exclude', type=click.STRING)
-@click.option('--backup/--no-backup', default=False)
-@click.option('--runner')
-@click.option('--use-coverage', is_flag=True, default=False)
-@click.option('--use-patch-file', help='Only mutate lines added/changed in the given patch file')
-@click.option('--tests-dir')
-@click.option('-m', '--test-time-multiplier', default=2.0, type=float)
-@click.option('-b', '--test-time-base', default=0.0, type=float)
-@click.option('-s', '--swallow-output', help='turn off output capture', is_flag=True)
+@click.argument('id-or-file', nargs=1, required=False)
+@click.argument('only-filenames', nargs=1, required=False)  # TODO: this could be changed to be an option, but this would be a not backwards compatible change to the CLI
 @click.option('--dict-synonyms')
-@click.option('--cache-only', is_flag=True, default=False)
-@click.option('--version', is_flag=True, default=False)
-@click.option('--suspicious-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
-@click.option('--untested-policy', type=click.Choice(['ignore', 'skipped', 'error', 'failure']), default='ignore')
-@click.option('--pre-mutation')
-@click.option('--post-mutation')
-@click.option('--simple-output', is_flag=True, default=False, help="Swap emojis in mutmut output to plain text alternatives.")
-@click.option('--no-progress', is_flag=True, default=False, help="Disable real-time progress indicator")
 @config_from_setup_cfg(
     dict_synonyms='',
-    paths_to_exclude='',
-    runner=DEFAULT_RUNNER,
-    tests_dir='tests/:test/',
-    pre_mutation=None,
-    post_mutation=None,
-    use_patch_file=None,
 )
-def show(argument, argument2, paths_to_mutate, disable_mutation_types, enable_mutation_types,
-        backup, runner, tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage, 
-        dict_synonyms, cache_only, version, suspicious_policy, untested_policy, pre_mutation, 
-        post_mutation, use_patch_file, paths_to_exclude, simple_output, no_progress):
+def show(id_or_file, only_filenames, dict_synonyms):
     """
-commands:\n
-    run [mutation id]\n
-        Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.\n
-    results\n
-        Print the results.\n
-    result-ids survived (or any other of: killed,timeout,suspicious,skipped,untested)\n
-        Print the IDs of the specified mutant classes (separated by spaces).\n
-    apply [mutation id]\n
-        Apply a mutation on disk.\n
-    show [mutation id]\n
+    show [mutation id or filename]\n
         Show a mutation diff.\n
-    show [path to file]\n
-        Show all mutation diffs for this file.\n
-    junitxml\n
-        Show a mutation diff with junitxml format.
     """
-    if test_time_base is None:  # click sets the default=0.0 to None
-        test_time_base = 0.0
-    if test_time_multiplier is None:  # click sets the default=0.0 to None
-        test_time_multiplier = 0.0
-    sys.exit(main("show", argument, argument2, paths_to_mutate, disable_mutation_types, 
-                  enable_mutation_types, backup, runner,
-                  tests_dir, test_time_multiplier, test_time_base,
-                  swallow_output, use_coverage, dict_synonyms, cache_only,
-                  version, suspicious_policy, untested_policy, pre_mutation,
-                  post_mutation, use_patch_file, paths_to_exclude, simple_output,
-                  no_progress))
+    if not id_or_file:
+        print_result_cache()
+        sys.exit(0)
+
+    if id_or_file == 'all':
+        print_result_cache(show_diffs=True, dict_synonyms=dict_synonyms, print_only_filename=only_filenames)
+        sys.exit(0)
+
+    if os.path.isfile(id_or_file):
+        print_result_cache(show_diffs=True, only_this_file=id_or_file)
+        sys.exit(0)
+
+    print(get_unified_diff(id_or_file, dict_synonyms))
+    sys.exit(0)
 
 
 @climain.command(context_settings=dict(help_option_names=['-h', '--help']))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -123,7 +123,7 @@ runner=python -m hammett -x
 
 
 def test_print_version():
-    assert CliRunner().invoke(climain, ['--version']).output.strip() == f'mutmut version {__version__}'
+    assert CliRunner().invoke(climain, ['version']).output.strip() == f'mutmut version {__version__}'
 
 
 def test_compute_return_code():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -25,6 +25,7 @@ from mutmut import (
     python_source_files,
     read_coverage_data,
     MUTANT_STATUSES,
+    __version__,
 )
 from mutmut.__main__ import climain
 
@@ -119,6 +120,10 @@ runner=python -m hammett -x
 
     with open(join(test_dir, "tests", "test_foo.py"), 'w') as f:
         f.write(test_file_contents)
+
+
+def test_print_version():
+    assert CliRunner().invoke(climain, ['--version']).output.strip() == f'mutmut version {__version__}'
 
 
 def test_compute_return_code():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -661,14 +661,15 @@ Survived 🙁 (2)
 """.strip()
 
 
-def test_html_output(filesystem):
-    CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0"], catch_exceptions=False)
+def test_html_output(surviving_mutants_filesystem):
+    result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0"], catch_exceptions=False)
+    print(repr(result.output))
     result = CliRunner().invoke(climain, ['html'])
     assert os.path.isfile("html/index.html")
     with open("html/index.html") as f:
         assert f.read() == (
             '<h1>Mutation testing report</h1>'
-            'Killed 14 out of 14 mutants'
+            'Killed 0 out of 2 mutants'
             '<table><thead><tr><th>File</th><th>Total</th><th>Killed</th><th>% killed</th><th>Survived</th></thead>'
-            '<tr><td><a href="foo.py.html">foo.py</a></td><td>14</td><td>14</td><td>100.00</td><td>0</td>'
+            '<tr><td><a href="foo.py.html">foo.py</a></td><td>2</td><td>0</td><td>0.00</td><td>2</td>'
             '</table></body></html>')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -86,6 +86,21 @@ def single_mutant_filesystem(tmpdir):
     mutmut.cache.db.schema = None
 
 
+@pytest.fixture
+def surviving_mutants_filesystem(tmpdir):
+    foo_py = """
+def foo(a, b):
+    result = a + b
+    return result
+"""
+
+    test_py = """
+def test_nothing(): assert True
+"""
+
+    create_filesystem(tmpdir, foo_py, test_py)
+
+
 def create_filesystem(tmpdir, file_to_mutate_contents, test_file_contents):
     test_dir = str(tmpdir)
     os.chdir(test_dir)
@@ -251,6 +266,20 @@ def test_simple_apply(filesystem):
     assert result.exit_code == 0
     with open(os.path.join(str(filesystem), 'foo.py')) as f:
         assert f.read() != file_to_mutate_contents
+
+
+def test_simply_apply_with_backup(filesystem):
+    result = CliRunner().invoke(climain, ['run', '-s', '--paths-to-mutate=foo.py', "--test-time-base=15.0"], catch_exceptions=False)
+    print(repr(result.output))
+    assert result.exit_code == 0
+
+    result = CliRunner().invoke(climain, ['apply', '--backup', '1'], catch_exceptions=False)
+    print(repr(result.output))
+    assert result.exit_code == 0
+    with open(os.path.join(str(filesystem), 'foo.py')) as f:
+        assert f.read() != file_to_mutate_contents
+    with open(os.path.join(str(filesystem), 'foo.py.bak')) as f:
+        assert f.read() == file_to_mutate_contents
 
 
 def test_full_run_no_surviving_mutants(filesystem):
@@ -506,7 +535,7 @@ def test_select_unknown_mutation_type(option):
         ]
     )
     assert result.exception.code == 2
-    assert f"The following are not valid mutation types: foo, bar. Valid mutation types are: {', '.join(mutations_by_type.keys())}" in result.output
+    assert f"The following are not valid mutation types: foo, bar. Valid mutation types are: {', '.join(mutations_by_type.keys())}" in result.output, result.output
 
 
 def test_enable_and_disable_mutation_type_are_exclusive():
@@ -520,3 +549,126 @@ def test_enable_and_disable_mutation_type_are_exclusive():
     )
     assert result.exception.code == 2
     assert "You can't combine --disable-mutation-types and --enable-mutation-types" in result.output
+
+
+def test_show(surviving_mutants_filesystem):
+    CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0"], catch_exceptions=False)
+    result = CliRunner().invoke(climain, ['show'])
+    assert result.output.strip() == """
+To apply a mutant on disk:
+    mutmut apply <id>
+
+To show a mutant:
+    mutmut show <id>
+
+
+Survived 🙁 (2)
+
+---- foo.py (2) ----
+
+1-2
+""".strip()
+
+
+def test_show_single_id(surviving_mutants_filesystem):
+    CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0"], catch_exceptions=False)
+    result = CliRunner().invoke(climain, ['show', '1'])
+    assert result.output.strip() == """
+--- foo.py
++++ foo.py
+@@ -1,5 +1,5 @@
+ 
+ def foo(a, b):
+-    result = a + b
++    result = a - b
+     return result
+""".strip()
+
+
+def test_show_all(surviving_mutants_filesystem):
+    CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0"], catch_exceptions=False)
+    result = CliRunner().invoke(climain, ['show', 'all'])
+    assert result.output.strip() == """
+To apply a mutant on disk:
+    mutmut apply <id>
+
+To show a mutant:
+    mutmut show <id>
+
+
+Survived 🙁 (2)
+
+---- foo.py (2) ----
+
+# mutant 1
+--- foo.py
++++ foo.py
+@@ -1,5 +1,5 @@
+ 
+ def foo(a, b):
+-    result = a + b
++    result = a - b
+     return result
+ 
+
+# mutant 2
+--- foo.py
++++ foo.py
+@@ -1,5 +1,5 @@
+ 
+ def foo(a, b):
+-    result = a + b
++    result = None
+     return result
+""".strip()
+
+
+def test_show_for_file(surviving_mutants_filesystem):
+    CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0"], catch_exceptions=False)
+    result = CliRunner().invoke(climain, ['show', 'foo.py'])
+    assert result.output.strip() == """
+To apply a mutant on disk:
+    mutmut apply <id>
+
+To show a mutant:
+    mutmut show <id>
+
+
+Survived 🙁 (2)
+
+---- foo.py (2) ----
+
+# mutant 1
+--- foo.py
++++ foo.py
+@@ -1,5 +1,5 @@
+ 
+ def foo(a, b):
+-    result = a + b
++    result = a - b
+     return result
+ 
+
+# mutant 2
+--- foo.py
++++ foo.py
+@@ -1,5 +1,5 @@
+ 
+ def foo(a, b):
+-    result = a + b
++    result = None
+     return result
+""".strip()
+
+
+def test_html_output(filesystem):
+    CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0"], catch_exceptions=False)
+    result = CliRunner().invoke(climain, ['html'])
+    assert os.path.isfile("html/index.html")
+    with open("html/index.html") as f:
+        assert f.read() == (
+            '<h1>Mutation testing report</h1>'
+            'Killed 14 out of 14 mutants'
+            '<table><thead><tr><th>File</th><th>Total</th><th>Killed</th><th>% killed</th><th>Survived</th></thead>'
+            '<tr><td><a href="foo.py.html">foo.py</a></td><td>14</td><td>14</td><td>100.00</td><td>0</td>'
+            '</table></body></html>')


### PR DESCRIPTION
This PR refactors ``__main__.py`` to make use of ``Click``'s subcommand feature.

This has the following benefits:
* The end user can use the ``--help`` option more effectively, as he is only shown the options which are actually necessary for this command
* The arguments can now be named according to their intent. As they were used for different subcommands previously, they were generically named ``argument`` and ``argument2``.
* The ``main()`` function (now named ``do_run()``) is now only responsible for handling the logic of the ``run`` command. Before it also had additional responsibilities like checking and evaluating the input parameters from the command line, and delegating/executing the logic for the other commands.

This change is _almost_ backwards compatible. The only thing I could not get to work the same way as before is the ``mutmut --version`` command. This is now a normal command and has to be invoked with ``mutmut version``.
It may be discussed if this should lead to a bump in the major version. I left the version number as it is right now.

I added test cases for the commands and options that were not covered so far (with exception for the ``--dict-synonyms`` option). They are in the same integration test style as the existing tests. 

While assessing the existing commands and options, I noticed a few things in the code that might be addressed in new issues. I left them untouched for now:
* The previous ``main`` also deals with command ``diff`` as synonym for ``show``, which cannot be passed through the CLI because is was not in the ``valid_commands`` list. I did not include a subcommand for ``diff`` as it could not be executed before as well.
* ``Config`` stores ``backup`` as instance attribute, which is never accessed. It is only used by the ``apply`` command, but here it is used directly and is not read from the ``Config`` instance. Should this be removed?
* The ``--cache_only`` option does not seem to do anything.
* ``mutmut show all True`` is not working as intended - it only shows the number of surviving mutants, not the filenames.
* Some of the tests that rely on the ``filesystem`` fixture are somehow interdependent - ``test_html_output`` failed if using the existing ``filesystem`` fixture and it is run together with other tests because all mutants are skipped/untested, but if run standalone this does not happen.
* In ``run``: it is probably not necessary to guess the paths to mutate if an argument is given. 


Feedback is welcome. 

Closes #56 