### PR TITLE
Remove ``--cache-only`` option and second argument to ``mutmut show``

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,18 +8,6 @@ on:
     - master
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Setup tox
-        run: pip install tox
-      - name: Run linting
-        run: tox -e lint
   test:
     strategy:
       fail-fast: false

--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -808,7 +808,7 @@ def run_mutation(context: Context, callback) -> str:
 class Config(object):
     def __init__(self, swallow_output, test_command, covered_lines_by_filename,
                  baseline_time_elapsed, test_time_multiplier, test_time_base,
-                 dict_synonyms, total, using_testmon, cache_only,
+                 dict_synonyms, total, using_testmon,
                  tests_dirs, hash_of_tests, pre_mutation, post_mutation,
                  coverage_data, paths_to_mutate, mutation_types_to_apply, no_progress):
         self.swallow_output = swallow_output
@@ -820,7 +820,6 @@ class Config(object):
         self.dict_synonyms = dict_synonyms
         self.total = total
         self.using_testmon = using_testmon
-        self.cache_only = cache_only
         self.tests_dirs = tests_dirs
         self.hash_of_tests = hash_of_tests
         self.post_mutation = post_mutation

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -182,12 +182,11 @@ def apply(mutation_id, backup, dict_synonyms):
 
 @climain.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.argument('id-or-file', nargs=1, required=False)
-@click.argument('only-filenames', nargs=1, required=False)  # TODO: this could be changed to be an option, but this would be a not backwards compatible change to the CLI
 @click.option('--dict-synonyms')
 @config_from_setup_cfg(
     dict_synonyms='',
 )
-def show(id_or_file, only_filenames, dict_synonyms):
+def show(id_or_file, dict_synonyms):
     """
     Show a mutation diff.
     """
@@ -196,7 +195,7 @@ def show(id_or_file, only_filenames, dict_synonyms):
         sys.exit(0)
 
     if id_or_file == 'all':
-        print_result_cache(show_diffs=True, dict_synonyms=dict_synonyms, print_only_filename=only_filenames)
+        print_result_cache(show_diffs=True, dict_synonyms=dict_synonyms)
         sys.exit(0)
 
     if os.path.isfile(id_or_file):

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -111,7 +111,6 @@ def version():
 @click.option('-b', '--test-time-base', default=0.0, type=float)
 @click.option('-s', '--swallow-output', help='turn off output capture', is_flag=True)
 @click.option('--dict-synonyms')
-@click.option('--cache-only', is_flag=True, default=False)
 @click.option('--pre-mutation')
 @click.option('--post-mutation')
 @click.option('--simple-output', is_flag=True, default=False, help="Swap emojis in mutmut output to plain text alternatives.")
@@ -127,7 +126,7 @@ def version():
 )
 def run(argument, paths_to_mutate, disable_mutation_types, enable_mutation_types, runner,
         tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage,
-        dict_synonyms, cache_only, pre_mutation, post_mutation, use_patch_file, paths_to_exclude,
+        dict_synonyms, pre_mutation, post_mutation, use_patch_file, paths_to_exclude,
         simple_output, no_progress):
     """
     Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.
@@ -139,7 +138,7 @@ def run(argument, paths_to_mutate, disable_mutation_types, enable_mutation_types
 
     sys.exit(do_run(argument, paths_to_mutate, disable_mutation_types, enable_mutation_types, runner,
                     tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage,
-                    dict_synonyms, cache_only, pre_mutation, post_mutation, use_patch_file, paths_to_exclude,
+                    dict_synonyms, pre_mutation, post_mutation, use_patch_file, paths_to_exclude,
                     simple_output, no_progress))
 
 
@@ -238,7 +237,7 @@ def html(dict_synonyms):
 
 def do_run(argument, paths_to_mutate, disable_mutation_types,
            enable_mutation_types, runner, tests_dir, test_time_multiplier, test_time_base,
-           swallow_output, use_coverage, dict_synonyms, cache_only, pre_mutation, post_mutation,
+           swallow_output, use_coverage, dict_synonyms, pre_mutation, post_mutation,
            use_patch_file, paths_to_exclude, simple_output, no_progress):
     """return exit code, after performing an mutation test run.
 
@@ -381,7 +380,6 @@ Legend for output:
         baseline_time_elapsed=baseline_time_elapsed,
         dict_synonyms=dict_synonyms,
         using_testmon=using_testmon,
-        cache_only=cache_only,
         tests_dirs=tests_dirs,
         hash_of_tests=current_hash_of_tests,
         test_time_multiplier=test_time_multiplier,

--- a/mutmut/cache.py
+++ b/mutmut/cache.py
@@ -149,7 +149,7 @@ def ranges(numbers):
 
 @init_db
 @db_session
-def print_result_cache(show_diffs=False, dict_synonyms=None, print_only_filename=None, only_this_file=None):
+def print_result_cache(show_diffs=False, dict_synonyms=None, only_this_file=None):
     print('To apply a mutant on disk:')
     print('    mutmut apply <id>')
     print('')
@@ -163,9 +163,6 @@ def print_result_cache(show_diffs=False, dict_synonyms=None, print_only_filename
             print('')
             print("{} ({})".format(title, len(mutant_list)))
             for filename, mutants in groupby(mutant_list, key=lambda x: x.line.sourcefile.filename):
-                if print_only_filename is not None and print_only_filename != filename:
-                    continue
-
                 if only_this_file and filename != only_this_file:
                     continue
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def testdata():
+    return Path(__file__).parent / "testdata"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -575,95 +575,22 @@ Survived 🙁 (2)
 """.strip()
 
 
-def test_show_single_id(surviving_mutants_filesystem):
+def test_show_single_id(surviving_mutants_filesystem, testdata):
     CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0"], catch_exceptions=False)
     result = CliRunner().invoke(climain, ['show', '1'])
-    assert result.output.strip() == """
---- foo.py
-+++ foo.py
-@@ -1,5 +1,5 @@
- 
- def foo(a, b):
--    result = a + b
-+    result = a - b
-     return result
-""".strip()
+    assert result.output.strip() == (testdata / "surviving_mutants_show_id_1.txt").read_text("utf8").strip()
 
 
-def test_show_all(surviving_mutants_filesystem):
+def test_show_all(surviving_mutants_filesystem, testdata):
     CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0"], catch_exceptions=False)
     result = CliRunner().invoke(climain, ['show', 'all'])
-    assert result.output.strip() == """
-To apply a mutant on disk:
-    mutmut apply <id>
-
-To show a mutant:
-    mutmut show <id>
+    assert result.output.strip() == (testdata / "surviving_mutants_show_all.txt").read_text("utf8").strip()
 
 
-Survived 🙁 (2)
-
----- foo.py (2) ----
-
-# mutant 1
---- foo.py
-+++ foo.py
-@@ -1,5 +1,5 @@
- 
- def foo(a, b):
--    result = a + b
-+    result = a - b
-     return result
- 
-
-# mutant 2
---- foo.py
-+++ foo.py
-@@ -1,5 +1,5 @@
- 
- def foo(a, b):
--    result = a + b
-+    result = None
-     return result
-""".strip()
-
-
-def test_show_for_file(surviving_mutants_filesystem):
+def test_show_for_file(surviving_mutants_filesystem, testdata):
     CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0"], catch_exceptions=False)
     result = CliRunner().invoke(climain, ['show', 'foo.py'])
-    assert result.output.strip() == """
-To apply a mutant on disk:
-    mutmut apply <id>
-
-To show a mutant:
-    mutmut show <id>
-
-
-Survived 🙁 (2)
-
----- foo.py (2) ----
-
-# mutant 1
---- foo.py
-+++ foo.py
-@@ -1,5 +1,5 @@
- 
- def foo(a, b):
--    result = a + b
-+    result = a - b
-     return result
- 
-
-# mutant 2
---- foo.py
-+++ foo.py
-@@ -1,5 +1,5 @@
- 
- def foo(a, b):
--    result = a + b
-+    result = None
-     return result
-""".strip()
+    assert result.output.strip() == (testdata / "surviving_mutants_show_foo_py.txt").read_text("utf8").strip()
 
 
 def test_html_output(surviving_mutants_filesystem):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -582,7 +582,7 @@ def test_show_single_id(surviving_mutants_filesystem):
 --- foo.py
 +++ foo.py
 @@ -1,5 +1,5 @@
-
+ 
  def foo(a, b):
 -    result = a + b
 +    result = a - b
@@ -609,18 +609,18 @@ Survived 🙁 (2)
 --- foo.py
 +++ foo.py
 @@ -1,5 +1,5 @@
-
+ 
  def foo(a, b):
 -    result = a + b
 +    result = a - b
      return result
-
+ 
 
 # mutant 2
 --- foo.py
 +++ foo.py
 @@ -1,5 +1,5 @@
-
+ 
  def foo(a, b):
 -    result = a + b
 +    result = None
@@ -647,18 +647,18 @@ Survived 🙁 (2)
 --- foo.py
 +++ foo.py
 @@ -1,5 +1,5 @@
-
+ 
  def foo(a, b):
 -    result = a + b
 +    result = a - b
      return result
-
+ 
 
 # mutant 2
 --- foo.py
 +++ foo.py
 @@ -1,5 +1,5 @@
-
+ 
  def foo(a, b):
 -    result = a + b
 +    result = None

--- a/tests/testdata/surviving_mutants_show_all.txt
+++ b/tests/testdata/surviving_mutants_show_all.txt
@@ -1,0 +1,31 @@
+To apply a mutant on disk:
+    mutmut apply <id>
+
+To show a mutant:
+    mutmut show <id>
+
+
+Survived 🙁 (2)
+
+---- foo.py (2) ----
+
+# mutant 1
+--- foo.py
++++ foo.py
+@@ -1,5 +1,5 @@
+ 
+ def foo(a, b):
+-    result = a + b
++    result = a - b
+     return result
+ 
+
+# mutant 2
+--- foo.py
++++ foo.py
+@@ -1,5 +1,5 @@
+ 
+ def foo(a, b):
+-    result = a + b
++    result = None
+     return result

--- a/tests/testdata/surviving_mutants_show_foo_py.txt
+++ b/tests/testdata/surviving_mutants_show_foo_py.txt
@@ -1,0 +1,31 @@
+To apply a mutant on disk:
+    mutmut apply <id>
+
+To show a mutant:
+    mutmut show <id>
+
+
+Survived 🙁 (2)
+
+---- foo.py (2) ----
+
+# mutant 1
+--- foo.py
++++ foo.py
+@@ -1,5 +1,5 @@
+ 
+ def foo(a, b):
+-    result = a + b
++    result = a - b
+     return result
+ 
+
+# mutant 2
+--- foo.py
++++ foo.py
+@@ -1,5 +1,5 @@
+ 
+ def foo(a, b):
+-    result = a + b
++    result = None
+     return result

--- a/tests/testdata/surviving_mutants_show_id_1.txt
+++ b/tests/testdata/surviving_mutants_show_id_1.txt
@@ -1,0 +1,8 @@
+--- foo.py
++++ foo.py
+@@ -1,5 +1,5 @@
+ 
+ def foo(a, b):
+-    result = a + b
++    result = a - b
+     return result


### PR DESCRIPTION
Closes #229 
Closes #230

This is also a great chance to see if the new CI workflow is working as intended.
I inadvertently broke some tests with the last PR because ``flake8`` was not happy with some trailing whitespace in the expected output.
I reverted those changes, but this should now lead to a failure in the linting stage. Let's see if the ``continue-on-error`` option works as intended!

But for the final solution I will try to find a way to satisfy ``flake8`` without breaking the tests.