### PR TITLE
Improve test selection through ``pre_mutation(context)``

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,9 @@ Changelog
   to check which parameters are relevant to this specific subcommand. The change is backwards compatible, and all existing commands
   work the same as before, with the exception of ``mutmut --version``, which now has to be ``mutmut version``.
 
+* You can now set the ``context.config.test_command`` in the ``mutmut_config.pre_mutation(context)`` hook to select the relevant subset of tests.
+  Coverage contexts are now accessible in ``config.coverage_data`` to help with the selection.
+
 2.2.0
 ~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -327,7 +327,7 @@ Pay attention that the format of the context name varies depending on the tool y
 For example, the ``pytest-cov`` plugin uses ``::`` as separator between module and test function.
 Furthermore, not all tools are able to correctly pick up the correct contexts. ``coverage.py`` for instance is (at the time of writing)
 unable to pick up tests that are inside a class when using ``pytest``.
-You will have to inspect your ``.coverage`` database using the [Coverage.py API](https://coverage.readthedocs.io/en/coverage-5.5/api.html)
+You will have to inspect your ``.coverage`` database using the `Coverage.py API <https://coverage.readthedocs.io/en/coverage-5.5/api.html>`_
 first to determine how you can extract the correct information to use with your test runner.
 
 Making things more robust

--- a/README.rst
+++ b/README.rst
@@ -198,7 +198,7 @@ If you have a large test suite or long running tests, it can be beneficial to na
 run for each mutant down to the tests that have a chance of killing it.
 Determining the relevant subset of tests depends on your project, its structure, and the metadata that you
 know about your tests.
-``mutmut`` provides information like the file to mutate and [coverage contexts](https://coverage.readthedocs.io/en/coverage-5.5/contexts.html)
+``mutmut`` provides information like the file to mutate and `coverage contexts <https://coverage.readthedocs.io/en/coverage-5.5/contexts.html>`_
 (if used with the ``--use-coverage`` switch).
 You can set the ``context.config.test_command`` in the ``pre_mutation(context)`` hook of ``mutmut_config.py``.
 The ``test_command`` is reset after each mutant, so you don't have to explicitly (re)set it for each mutant.
@@ -207,7 +207,7 @@ This section gives examples to show how this could be done for some concrete use
 All examples use the default test runner (``python -m pytest -x --assert=plain``).
 
 Selection based on source and test layout
-=========================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If the location of the test module has a strict correlation with your source code layout, you can simply
 construct the path to the corresponding test file from ``context.filename``.
@@ -226,6 +226,7 @@ production code:
 Your ``mutmut_config.py`` in this case would look like this:
 
 .. code-block:: python
+
     import os.path
 
     def pre_mutation(context):
@@ -234,7 +235,7 @@ Your ``mutmut_config.py`` in this case would look like this:
         context.config.test_command += ' ' + os.path.join(dirname, testfile)
 
 Selection based on imports
-==========================
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If you can't rely on the directory structure or naming of the test files, you may assume that the tests most likely
 to kill the mutant are located in test files that directly import the module that is affected by the mutant.
@@ -284,9 +285,9 @@ imports which module, and then lookup all test files importing the mutated modul
         context.config.test_command += f"{' '.join(tests_to_run)}"
 
 Selection based on coverage contexts
-====================================
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you recorded [coverage contexts](https://coverage.readthedocs.io/en/coverage-5.5/contexts.html) and use
+If you recorded `coverage contexts <https://coverage.readthedocs.io/en/coverage-5.5/contexts.html>`_ and use
 the ``--use-coverage`` switch, you can access this coverage data inside the ``pre_mutation(context)`` hook
 via the ``context.config.coverage_data`` attribute. This attribute is a dictionary in the form
 ``{filename: {lineno: [contexts]}}``.
@@ -330,7 +331,7 @@ You will have to inspect your ``.coverage`` database using the [Coverage.py API]
 first to determine how you can extract the correct information to use with your test runner.
 
 Making things more robust
-=========================
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Despite your best efforts in picking the right subset of tests, it may happen that the mutant survives because the test which is able
 to kill it was not included in the test set. You can tell ``mutmut`` to re-run the full test suite in that case, to verify that this

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -106,6 +106,9 @@ def version():
 @click.option('--runner')
 @click.option('--use-coverage', is_flag=True, default=False)
 @click.option('--use-patch-file', help='Only mutate lines added/changed in the given patch file')
+@click.option('--rerun-all', is_flag=True, default=False, help='If you modified the test_command in the pre_mutation hook, '
+                                                               'the default test_command (specified by the "runner" option) '
+                                                               'will be executed if the mutant survives with your modified test_command.')
 @click.option('--tests-dir')
 @click.option('-m', '--test-time-multiplier', default=2.0, type=float)
 @click.option('-b', '--test-time-base', default=0.0, type=float)
@@ -127,7 +130,7 @@ def version():
 def run(argument, paths_to_mutate, disable_mutation_types, enable_mutation_types, runner,
         tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage,
         dict_synonyms, pre_mutation, post_mutation, use_patch_file, paths_to_exclude,
-        simple_output, no_progress):
+        simple_output, no_progress, rerun_all):
     """
     Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.
     """
@@ -139,7 +142,7 @@ def run(argument, paths_to_mutate, disable_mutation_types, enable_mutation_types
     sys.exit(do_run(argument, paths_to_mutate, disable_mutation_types, enable_mutation_types, runner,
                     tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage,
                     dict_synonyms, pre_mutation, post_mutation, use_patch_file, paths_to_exclude,
-                    simple_output, no_progress))
+                    simple_output, no_progress, rerun_all))
 
 
 @climain.command(context_settings=dict(help_option_names=['-h', '--help']))
@@ -237,7 +240,7 @@ def html(dict_synonyms):
 def do_run(argument, paths_to_mutate, disable_mutation_types,
            enable_mutation_types, runner, tests_dir, test_time_multiplier, test_time_base,
            swallow_output, use_coverage, dict_synonyms, pre_mutation, post_mutation,
-           use_patch_file, paths_to_exclude, simple_output, no_progress):
+           use_patch_file, paths_to_exclude, simple_output, no_progress, rerun_all):
     """return exit code, after performing an mutation test run.
 
     :return: the exit code from executing the mutation tests
@@ -387,7 +390,8 @@ Legend for output:
         post_mutation=post_mutation,
         paths_to_mutate=paths_to_mutate,
         mutation_types_to_apply=mutation_types_to_apply,
-        no_progress=no_progress
+        no_progress=no_progress,
+        rerun_all=rerun_all
     )
 
     parse_run_argument(argument, config, dict_synonyms, mutations_by_file, paths_to_exclude, paths_to_mutate, tests_dirs)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -322,7 +322,7 @@ def test_mutant_only_killed_after_rerun(filesystem):
     mutmut_config = filesystem / "mutmut_config.py"
     mutmut_config.write("""
 def pre_mutation(context):
-    context.config.test_command = "True"
+    context.config.test_command = "echo True"
 """)
     CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0", "--rerun-all"], catch_exceptions=False)
     result = CliRunner().invoke(climain, ['results'], catch_exceptions=False)
@@ -341,7 +341,7 @@ def test_no_rerun_if_not_specified(filesystem):
     mutmut_config = filesystem / "mutmut_config.py"
     mutmut_config.write("""
 def pre_mutation(context):
-    context.config.test_command = "True"
+    context.config.test_command = "echo True"
 """)
     CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0"], catch_exceptions=False)
     result = CliRunner().invoke(climain, ['results'], catch_exceptions=False)


### PR DESCRIPTION
Closes #227

After looking at the code and the last example in the discussion of the issue, I realised that most of the necessary logic was already present.
The changes to the code are minimal:

* Read the coverage contexts from the ``.coverage`` file instead only the covered lines
* Reset the ``config.test_command`` after each mutation run so that the user does not have to take care of this
* Add an option which tells ``mutmut`` to re-run the whole test suite if the mutant survives after running just the subset of tests.

The rest is documentation to give some concrete examples how to do this, not only for selection based on coverage contexts, but also other cases.

I decided to reuse the existing ``pre_mutation(context)`` hook, as a new function would just lead to duplications in the code and ``pre_mutation`` is reasonably suited for this. The current docs already describes this hook as 

> pre_mutation gets called before each mutant is applied and tested.

Let me know what you think!