### PR TITLE
Fix inconsistent output of ``mutmut show`` after using ``--enable-mutation-types``

### DIFF
--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -533,7 +533,9 @@ class Context(object):
             }
         return self._pragma_no_mutate_lines
 
-    def should_mutate(self):
+    def should_mutate(self, node):
+        if self.config and node.type not in self.config.mutation_types_to_apply:
+            return False
         if self.mutation_id == ALL:
             return True
         return self.mutation_id in (ALL, self.mutation_id_of_current_index)
@@ -599,9 +601,6 @@ def mutate_node(node, context):
             if context.performed_mutation_ids and context.mutation_id != ALL:
                 return
 
-        if context.config and node.type not in context.config.mutation_types_to_apply:
-            return
-
         mutation = mutations_by_type.get(node.type)
 
         if mutation is None:
@@ -634,7 +633,7 @@ def mutate_node(node, context):
                 if new is not None and new != old:
                     if hasattr(mutmut_config, 'pre_mutation_ast'):
                         mutmut_config.pre_mutation_ast(context=context)
-                    if context.should_mutate():
+                    if context.should_mutate(node):
                         context.performed_mutation_ids.append(context.mutation_id_of_current_index)
                         setattr(node, key, new)
                     context.index += 1


### PR DESCRIPTION
Closes #234

``mutmut show <id>`` did not show the same mutant that was created and tested with ``mutmut run`` because the ``index`` of the mutation did not match. 
By moving the logic if a mutation should be performed into ``Context.should_mutate(node)``, this is fixed.

Note: in the issue we discussed that it might be a good idea to mark the mutants that are not applied and run due to ``--enable-mutation-types`` or ``--disable-mutation-types`` as ``SKIPPED``.
This is not part of this PR, as implementing it would be tricky. Identifying the mutants and actually running them and setting a status is decoupled, and we'd have to add some means of tagging a mutant as "not-to-be-run" in some way.