### PR TITLE
Support paths with path separators

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -482,10 +482,9 @@ def test_use_coverage(filesystem):
 
     # remove existent path to check if an exception is thrown
     os.unlink(os.path.join(str(filesystem), 'foo.py'))
-    with pytest.raises(ValueError,
-                       match=r'^Filepaths in .coverage not recognized, try recreating the .coverage file manually.$'):
-        CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0", "--use-coverage"],
-                           catch_exceptions=False)
+    result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0", "--use-coverage"],
+                                catch_exceptions=False)
+    assert result.exit_code == 2
 
 
 def test_use_patch_file(filesystem):


### PR DESCRIPTION
Before this change, the patterns regex wasn't matching paths with a path separator, for example: `--paths-to-mutate foo/bar,foo/baz`, which resulted in:
```
  File "/home/ubuntu/mutmut/mutmut/cache.py", line 355, in update_line_numbers
    hash = hash_of(filename)
  File "/home/ubuntu/mutmut/mutmut/cache.py", line 93, in hash_of
    with open(filename, 'rb') as f:
FileNotFoundError: [Errno 2] No such file or directory: 'foo/bar,foo/baz'
```

This PR is filtering the input using `Path.exists` instead of relying on regex.