### PR TITLE
feat: describe how to use paths_to_mutate flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,14 +3,14 @@ mutmut - python mutation tester
 
 .. image:: https://travis-ci.org/boxed/mutmut.svg?branch=master
     :target: https://travis-ci.org/boxed/mutmut
- 
+
 .. image:: https://readthedocs.org/projects/mutmut/badge/?version=latest
     :target: https://mutmut.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
-    
+
 .. image:: https://codecov.io/gh/boxed/mutmut/branch/master/graph/badge.svg
   :target: https://codecov.io/gh/boxed/mutmut
-  
+
 .. image:: https://img.shields.io/discord/767914934016802818.svg
   :target: https://discord.gg/cwb9uNt
 
@@ -67,6 +67,15 @@ flags again, just run ``mutmut run`` and it works. Like this:
     runner=python -m hammett -x
     tests_dir=tests/
     dict_synonyms=Struct, NamedStruct
+
+To use multiple paths either in the ``paths_to_mutate`` or ``tests_dir`` option
+use a comma or colon separated list. For example:
+
+.. code-block:: ini
+
+    [mutmut]
+    paths_to_mutate=src/,src2/
+    tests_dir=tests/:tests2/
 
 You can stop the mutation run at any time and mutmut will restart where you
 left off. It's also smart enough to retest only the surviving mutants when the

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -270,6 +270,7 @@ def do_run(argument, paths_to_mutate, disable_mutation_types,
         paths_to_mutate = guess_paths_to_mutate()
 
     def split_paths(paths):
+        # This method is used to split paths that are separated by commas or colons
         for sep in [',', ':']:
             separated = list(filter(lambda p: Path(p).exists(), paths.split(sep)))
             if separated:
@@ -277,10 +278,16 @@ def do_run(argument, paths_to_mutate, disable_mutation_types,
         return None
 
     if not isinstance(paths_to_mutate, (list, tuple)):
+        # If the paths_to_mutate is a string, we split it by commas or colons
         paths_to_mutate = split_paths(paths_to_mutate)
 
     if not paths_to_mutate:
-        raise click.BadOptionUsage('--paths-to-mutate', 'You must specify a list of paths to mutate. Either as a command line argument, or by setting paths_to_mutate under the section [mutmut] in setup.cfg')
+        raise click.BadOptionUsage(
+            '--paths-to-mutate',
+            'You must specify a list of paths to mutate.'
+            'Either as a command line argument, or by setting paths_to_mutate under the section [mutmut] in setup.cfg.'
+            'To specify multiple paths, separate them with commas or colons (i.e: --paths-to-mutate=path1/,path2/path3/,path4/).'
+        )
 
     tests_dirs = []
     for p in split_paths(tests_dir):


### PR DESCRIPTION
After some time investigating how to properly use the `paths_to_mutate` setting (which is separating paths with commas `,` or colons `:`), I thought that it would be good to help future folks and new-comers that use this library by explaining how to use the `--paths-to-mutate` flag or `paths_to_mutate` configuration with a list of paths.

The **right way to do** it is:

```
--paths-to-mutate=/path1/,/path2/path3/,/path4/
```


Not:

```
--paths-to-mutate=["/path1/", "/path2/path3/", "/path4/"]
```

Nor:

```
--paths-to-mutate="/path1/ /path2/path3/ /path4/"
```

Neither:

```
--paths-to-mutate=path1/
--paths-to-mutate=path2/path3/
--paths-to-mutate=path4/
```
