### PR TITLE
Fixing junitxml line number, daemon warning, and missing argument in unit test

### DIFF
--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -1036,7 +1036,7 @@ def popen_streaming_output(cmd, callback, timeout=None):
 
     # python 2-3 agnostic process timer
     timer = Timer(timeout, kill, [process])
-    timer.setDaemon(True)
+    timer.daemon = True
     timer.start()
 
     while process.returncode is None:

--- a/mutmut/cache.py
+++ b/mutmut/cache.py
@@ -230,11 +230,15 @@ def _get_unified_diff(source, filename, mutation_id, dict_synonyms, update_cache
 @init_db
 @db_session
 def print_result_cache_junitxml(dict_synonyms, suspicious_policy, untested_policy):
+    print(create_junitxml_report(dict_synonyms, suspicious_policy, untested_policy))
+
+
+def create_junitxml_report(dict_synonyms, suspicious_policy, untested_policy):
     test_cases = []
     mutant_list = list(select(x for x in Mutant))
     for filename, mutants in groupby(mutant_list, key=lambda x: x.line.sourcefile.filename):
         for mutant in mutants:
-            tc = TestCase("Mutant #{}".format(mutant.id), file=filename, line=mutant.line.line_number, stdout=mutant.line.line)
+            tc = TestCase("Mutant #{}".format(mutant.id), file=filename, line=mutant.line.line_number + 1, stdout=mutant.line.line)
             if mutant.status == BAD_SURVIVED:
                 tc.add_failure_info(message=mutant.status, output=get_unified_diff(mutant.id, dict_synonyms))
             if mutant.status == BAD_TIMEOUT:
@@ -251,7 +255,7 @@ def print_result_cache_junitxml(dict_synonyms, suspicious_policy, untested_polic
             test_cases.append(tc)
 
     ts = TestSuite("mutmut", test_cases)
-    print(TestSuite.to_xml_string([ts]))
+    return TestSuite.to_xml_string([ts])
 
 
 @init_db

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -139,7 +139,7 @@ def test_compute_return_code():
     class MockProgress(Progress):
         def __init__(self, killed_mutants, surviving_mutants,
                      surviving_mutants_timeout, suspicious_mutants, **_):
-            super(MockProgress, self).__init__(total=0, output_legend={})
+            super(MockProgress, self).__init__(total=0, output_legend={}, no_progress=False)
             self.killed_mutants = killed_mutants
             self.surviving_mutants = surviving_mutants
             self.surviving_mutants_timeout = surviving_mutants_timeout


### PR DESCRIPTION
Issue: https://github.com/boxed/mutmut/issues/260

Changes:
1. Add to one to junitxml report line numbers to fix above issue
2. Fix a unit test that was missing the no_progress argument
3. Fix a daemon warning from the unit tests
4. Separate creating the junitxml report from printing it, so that it can be tested easier in the future.

All unit tests pass with these changes.