### PR TITLE
Fix bug with init db on wrong function

### DIFF
--- a/mutmut/cache.py
+++ b/mutmut/cache.py
@@ -227,12 +227,12 @@ def _get_unified_diff(source, filename, mutation_id, dict_synonyms, update_cache
     return output
 
 
-@init_db
-@db_session
 def print_result_cache_junitxml(dict_synonyms, suspicious_policy, untested_policy):
     print(create_junitxml_report(dict_synonyms, suspicious_policy, untested_policy))
 
 
+@init_db
+@db_session
 def create_junitxml_report(dict_synonyms, suspicious_policy, untested_policy):
     test_cases = []
     mutant_list = list(select(x for x in Mutant))


### PR DESCRIPTION
If you try to run it directly, the new function `create_junitxml_report` throws an error since the db is not initalized.

I'm sorry I didn't find this before my previous pull request.