### PR TITLE
Changing mutation decode from UTF-8 to Latin1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ docs/tri*.rst
 
 # tests
 results/
+
+#Pipenv
+Pipfile.lock
+

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,9 @@ junit-xml = "==1.8"
 toml = "*"
 
 [dev-packages]
+pytest = "*"
+hammett = "*"
+coverage = "*"
 
 [requires]
 python_version = "3.10"

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,17 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+glob2 = "*"
+parso = "*"
+click = "*"
+pony = "*"
+junit-xml = "==1.8"
+toml = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.10"

--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -1045,7 +1045,7 @@ def popen_streaming_output(cmd, callback, timeout=None):
                 line = stdout.readline()
                 # windows gives readline() raw stdout as a b''
                 # need to decode it
-                line = line.decode("utf-8")
+                line = line.decode("latin1")
                 if line:  # ignore empty strings and None
                     callback(line)
             else:


### PR DESCRIPTION
This change allows MUTMUT to analyze code which contains log messages and comments written in Latin-based languages without breaking.