### PR TITLE
adding "--CI" flag option to mutmut run command

### DIFF
--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -817,7 +817,7 @@ class Config(object):
                  baseline_time_elapsed, test_time_multiplier, test_time_base,
                  dict_synonyms, total, using_testmon,
                  tests_dirs, hash_of_tests, pre_mutation, post_mutation,
-                 coverage_data, paths_to_mutate, mutation_types_to_apply, no_progress, rerun_all):
+                 coverage_data, paths_to_mutate, mutation_types_to_apply, no_progress, ci, rerun_all):
         self.swallow_output = swallow_output
         self.test_command = self._default_test_command = test_command
         self.covered_lines_by_filename = covered_lines_by_filename
@@ -835,6 +835,7 @@ class Config(object):
         self.paths_to_mutate = paths_to_mutate
         self.mutation_types_to_apply = mutation_types_to_apply
         self.no_progress = no_progress
+        self.ci = ci
         self.rerun_all = rerun_all
 
 
@@ -1277,7 +1278,7 @@ def python_source_files(path, tests_dirs, paths_to_exclude=None):
         yield path
 
 
-def compute_exit_code(progress, exception=None):
+def compute_exit_code(progress, exception=None, ci=False):
     """Compute an exit code for mutmut mutation testing
 
     The following exit codes are available for mutmut:
@@ -1290,10 +1291,15 @@ def compute_exit_code(progress, exception=None):
      Exit codes 1 to 8 will be bit-ORed so that it is possible to know what
      different mutant statuses occurred during mutation testing.
 
+     When running with ci=True (--CI flag enabled), the exit code will always be
+     1 for a fatal error or 0 for any other case.
+
     :param exception:
     :type exception: Exception
     :param progress:
     :type progress: Progress
+    :param ci:
+    :type ci: bool
 
     :return: integer noting the exit code of the mutation tests.
     :rtype: int
@@ -1301,6 +1307,8 @@ def compute_exit_code(progress, exception=None):
     code = 0
     if exception is not None:
         code = code | 1
+    if ci:
+        return code
     if progress.surviving_mutants > 0:
         code = code | 2
     if progress.surviving_mutants_timeout > 0:

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -116,6 +116,7 @@ def version():
 @click.option('--post-mutation')
 @click.option('--simple-output', is_flag=True, default=False, help="Swap emojis in mutmut output to plain text alternatives.")
 @click.option('--no-progress', is_flag=True, default=False, help="Disable real-time progress indicator")
+@click.option('--CI', is_flag=True, default=False, help="Returns an exit code of 0 for all successful runs and an exit code of 1 for fatal errors.")
 @config_from_file(
     dict_synonyms='',
     paths_to_exclude='',
@@ -128,7 +129,7 @@ def version():
 def run(argument, paths_to_mutate, disable_mutation_types, enable_mutation_types, runner,
         tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage,
         dict_synonyms, pre_mutation, post_mutation, use_patch_file, paths_to_exclude,
-        simple_output, no_progress, rerun_all):
+        simple_output, no_progress, ci, rerun_all):
     """
     Runs mutmut. You probably want to start with just trying this. If you supply a mutation ID mutmut will check just this mutant.
     """
@@ -140,7 +141,7 @@ def run(argument, paths_to_mutate, disable_mutation_types, enable_mutation_types
     sys.exit(do_run(argument, paths_to_mutate, disable_mutation_types, enable_mutation_types, runner,
                     tests_dir, test_time_multiplier, test_time_base, swallow_output, use_coverage,
                     dict_synonyms, pre_mutation, post_mutation, use_patch_file, paths_to_exclude,
-                    simple_output, no_progress, rerun_all))
+                    simple_output, no_progress, ci, rerun_all))
 
 
 @climain.command(context_settings=dict(help_option_names=['-h', '--help']))
@@ -238,7 +239,7 @@ def html(dict_synonyms):
 def do_run(argument, paths_to_mutate, disable_mutation_types,
            enable_mutation_types, runner, tests_dir, test_time_multiplier, test_time_base,
            swallow_output, use_coverage, dict_synonyms, pre_mutation, post_mutation,
-           use_patch_file, paths_to_exclude, simple_output, no_progress, rerun_all):
+           use_patch_file, paths_to_exclude, simple_output, no_progress, ci, rerun_all):
     """return exit code, after performing an mutation test run.
 
     :return: the exit code from executing the mutation tests
@@ -388,6 +389,7 @@ Legend for output:
         paths_to_mutate=paths_to_mutate,
         mutation_types_to_apply=mutation_types_to_apply,
         no_progress=no_progress,
+        ci=ci,
         rerun_all=rerun_all
     )
 
@@ -405,7 +407,7 @@ Legend for output:
         traceback.print_exc()
         return compute_exit_code(progress, e)
     else:
-        return compute_exit_code(progress)
+        return compute_exit_code(progress, ci=ci)
     finally:
         print()  # make sure we end the output with a newline
         # Close all active multiprocessing queues to avoid hanging up the main process

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -181,6 +181,11 @@ def test_compute_return_code():
     assert compute_exit_code(MockProgress(1, 1, 1, 0), Exception()) == 7
     assert compute_exit_code(MockProgress(1, 1, 1, 1), Exception()) == 15
 
+    assert compute_exit_code(MockProgress(0, 0, 0, 0), ci=True) == 0
+    assert compute_exit_code(MockProgress(1, 1, 1, 1), ci=True) == 0
+    assert compute_exit_code(MockProgress(0, 0, 0, 0), Exception(), ci=True) == 1
+    assert compute_exit_code(MockProgress(1, 1, 1, 1), Exception(), ci=True) == 1
+
 
 def test_read_coverage_data(filesystem):
     assert read_coverage_data() == {}


### PR DESCRIPTION
As mentioned in #267, GitHub Actions requires an exit code of 0 to mark the run as successful. This is incompatible with the current return system that mutmut uses.

This PR adds a `--CI` flag option to `mutmut run` which forces the exit code to be 0 for a successful run, or 1 for a fatal error.