### PR TITLE
#183 Mutmut stops running

### DIFF
--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -1123,6 +1123,7 @@ def hammett_tests_pass(config, callback):
 
     return returncode == 0
 
+CYCLE_PROCESS_AFTER = 100
 
 def run_mutation_tests(config, progress, mutations_by_file):
     """
@@ -1161,7 +1162,7 @@ def run_mutation_tests(config, progress, mutations_by_file):
             kwargs=dict(
                 mutants_queue=mutants_queue,
                 results_queue=results_queue,
-                cycle_process_after=100,
+                cycle_process_after=CYCLE_PROCESS_AFTER,
             )
         )
         t.start()
@@ -1169,7 +1170,7 @@ def run_mutation_tests(config, progress, mutations_by_file):
 
     t = create_worker()
 
-    while t.is_alive():
+    while True:
         command, status, filename, mutation_id = results_queue.get()
         if command == 'end':
             t.join()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,10 +1,15 @@
 
+from time import sleep
 from pytest import raises
+from unittest.mock import MagicMock, patch
 
 from mutmut import (
     partition_node_list,
     name_mutation,
-    Context,
+    run_mutation_tests,
+    check_mutants,
+    OK_KILLED,
+    Context, 
     mutate)
 
 
@@ -23,3 +28,48 @@ def test_context_exclude_line():
 
     source = "__all__ = ['hi']\n"
     assert mutate(Context(source=source)) == (source, 0)
+
+
+def check_mutants_stub(**kwargs):
+    def run_mutation_stub(*_):
+        sleep(0.15)
+        return OK_KILLED
+    check_mutants_original = check_mutants
+    with patch('mutmut.run_mutation', run_mutation_stub):
+        check_mutants_original(**kwargs)
+
+class ConfigStub:
+    hash_of_tests = None
+config_stub = ConfigStub()
+
+def test_run_mutation_tests_thread_synchronization(monkeypatch):
+    # arrange
+    total_mutants = 3
+    cycle_process_after = 1
+
+    def queue_mutants_stub(**kwargs):
+        for _ in range(total_mutants):
+            kwargs['mutants_queue'].put(('mutant', Context(config=config_stub)))
+        kwargs['mutants_queue'].put(('end', None))
+    monkeypatch.setattr('mutmut.queue_mutants', queue_mutants_stub)
+
+    def update_mutant_status_stub(**_):
+        sleep(0.1)
+
+    monkeypatch.setattr('mutmut.check_mutants', check_mutants_stub)
+    monkeypatch.setattr('mutmut.cache.update_mutant_status', update_mutant_status_stub)
+    monkeypatch.setattr('mutmut.CYCLE_PROCESS_AFTER', cycle_process_after)
+
+    progress_mock = MagicMock()
+    progress_mock.registered_mutants = 0
+
+    def progress_mock_register(*_):
+        progress_mock.registered_mutants += 1
+        
+    progress_mock.register = progress_mock_register
+
+    # act
+    run_mutation_tests(config_stub, progress_mock, None)
+
+    # assert
+    assert progress_mock.registered_mutants == total_mutants


### PR DESCRIPTION
Hi! I stumbled upon this problem of hanging mutmut on process cycling. I'm experimenting with mutmut as a part of a CI pipeline After some debugging, I discovered that the actual hanging behaviour was caused by hanging `queue_mutants` thread, which hangs at `put` method of the mutant queue because it was full and there was no consumer to get the commands. 

However, the root cause (in my case, at least) was the race condition between results consumer loop (in `run_mutation_tests`) and mutant worker loop (in `check_mutants`). 

Results consumer loop depends its execution on `is_alive` method of the current worker. If worker sends `cycle` command and terminates before consumer loop finishes updating status of previous mutant (which happened in my case), the loop ends without attempting to recreating the worker, hence finishing execution of `run_mutation_tests` function. Such behavior caused dangling threads to hang the execution of parent process, hence making whole process both unresposive and unfinished.

The fix I propose is to remove dependency on the `is_alive` method of current worker process, by changing it to infinite loop. By introducing this change, the only way to end the loop is to receive `end` command, but with the `finally` sending it in worker loop, such possibility is quite unlikely.

Additionally, I added a test which exhibits this behaviour, however it's quite mock-heavy to make it focused on a race condition in question instead of making it full end-to-end test.

Tested on:
 - Windows 10, x86, Python 3.9.13
 - Ubuntu (WSL), x86, Python 3.8.10