### PR TITLE
Fix issue with `TypeError` for empty file diffs

### DIFF
--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -1220,7 +1220,7 @@ def read_patch_data(patch_file_path):
 
     return {
         diff.header.new_path: {change.new for change in diff.changes if change.old is None}
-        for diff in diffs
+        for diff in diffs if diff.changes
     }
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,7 @@
 
+from pathlib import Path
 from time import sleep
-from pytest import raises
+from pytest import raises, fixture
 from unittest.mock import MagicMock, patch
 
 from mutmut import (
@@ -8,6 +9,8 @@ from mutmut import (
     name_mutation,
     run_mutation_tests,
     check_mutants,
+    close_active_queues,
+    read_patch_data,
     OK_KILLED,
     Context, 
     mutate)
@@ -73,3 +76,95 @@ def test_run_mutation_tests_thread_synchronization(monkeypatch):
 
     # assert
     assert progress_mock.registered_mutants == total_mutants
+
+    close_active_queues()
+
+@fixture
+def testpatches_path(testdata: Path):
+    return testdata / "test_patches"
+
+def test_read_patch_data_new_empty_file_not_in_the_list(testpatches_path: Path):
+    # arrange
+    new_empty_file_name = "new_empty_file.txt"
+    new_empty_file_patch = testpatches_path / "add_empty_file.patch"
+
+    # act
+    new_empty_file_changes = read_patch_data(new_empty_file_patch)
+
+    # assert
+    assert not new_empty_file_name in new_empty_file_changes
+
+def test_read_patch_data_removed_empty_file_not_in_the_list(testpatches_path: Path):
+    # arrange
+    existing_empty_file_name = "existing_empty_file.txt"
+    remove_empty_file_patch = testpatches_path / "remove_empty_file.patch"
+
+    # act
+    remove_empty_file_changes = read_patch_data(remove_empty_file_patch)
+
+    # assert
+    assert existing_empty_file_name not in remove_empty_file_changes
+
+def test_read_patch_data_renamed_empty_file_not_in_the_list(testpatches_path: Path):
+    # arrange
+    renamed_empty_file_name = "renamed_existing_empty_file.txt"
+    renamed_empty_file_patch = testpatches_path / "renamed_empty_file.patch"
+
+    # act
+    renamed_empty_file_changes = read_patch_data(renamed_empty_file_patch)
+
+    # assert
+    assert renamed_empty_file_name not in renamed_empty_file_changes
+
+def test_read_patch_data_added_line_is_in_the_list(testpatches_path: Path):
+    # arrange
+    file_name = "existing_file.txt"
+    file_patch = testpatches_path / "add_new_line.patch"
+
+    # act
+    file_changes = read_patch_data(file_patch)
+
+    # assert
+    assert file_name in file_changes
+    assert file_changes[file_name] == {3} # line is added between second and third
+
+def test_read_patch_data_edited_line_is_in_the_list(testpatches_path: Path):
+    # arrange
+    file_name = "existing_file.txt"
+    file_patch = testpatches_path / "edit_existing_line.patch"
+
+    # act
+    file_changes = read_patch_data(file_patch)
+
+    # assert
+    assert file_name in file_changes
+    assert file_changes[file_name] == {2} # line is added between 2nd and 3rd
+
+def test_read_patch_data_renamed_file_edited_line_is_in_the_list(testpatches_path: Path):
+    # arrange
+    original_file_name = "existing_file.txt"
+    new_file_name = "renamed_existing_file.txt"
+    file_patch = testpatches_path / "edit_existing_renamed_file_line.patch"
+
+    # act
+    file_changes = read_patch_data(file_patch)
+
+    # assert
+    assert original_file_name not in file_changes
+    assert new_file_name in file_changes
+    assert file_changes[new_file_name] == {3} # 3rd line is edited
+
+def test_read_patch_data_mutliple_files(testpatches_path: Path):
+    # arrange
+    expected_changes = {
+        "existing_file.txt": {2, 3},
+        "existing_file_2.txt": {4, 5},
+        "new_file.txt": {1, 2, 3}
+    }
+    file_patch = testpatches_path / "multiple_files.patch"
+
+    # act
+    actual_changes = read_patch_data(file_patch)
+
+    # assert
+    assert actual_changes == expected_changes

--- a/tests/testdata/test_patches/add_empty_file.patch
+++ b/tests/testdata/test_patches/add_empty_file.patch
@@ -1,0 +1,3 @@
+diff --git a/new_empty_file.txt b/new_empty_file.txt
+new file mode 100644
+index 0000000..e69de29

--- a/tests/testdata/test_patches/add_new_line.patch
+++ b/tests/testdata/test_patches/add_new_line.patch
@@ -1,0 +1,10 @@
+diff --git a/existing_file.txt b/existing_file.txt
+index 272b2e4..6541a1f 100644
+--- a/existing_file.txt
++++ b/existing_file.txt
+@@ -1,3 +1,4 @@
+ first line
+ second line
++new line between second and third
+ third line
+\ No newline at end of file

--- a/tests/testdata/test_patches/edit_existing_line.patch
+++ b/tests/testdata/test_patches/edit_existing_line.patch
@@ -1,0 +1,10 @@
+diff --git a/existing_file.txt b/existing_file.txt
+index 272b2e4..9767587 100644
+--- a/existing_file.txt
++++ b/existing_file.txt
+@@ -1,3 +1,3 @@
+ first line
+-second line
++second line is edited
+ third line
+\ No newline at end of file

--- a/tests/testdata/test_patches/edit_existing_renamed_file_line.patch
+++ b/tests/testdata/test_patches/edit_existing_renamed_file_line.patch
@@ -1,0 +1,14 @@
+diff --git a/existing_file.txt b/renamed_existing_file.txt
+similarity index 52%
+rename from existing_file.txt
+rename to renamed_existing_file.txt
+index 272b2e4..a00934b 100644
+--- a/existing_file.txt
++++ b/renamed_existing_file.txt
+@@ -1,3 +1,3 @@
+ first line
+ second line
+-third line
+\ No newline at end of file
++third line is changed
+\ No newline at end of file

--- a/tests/testdata/test_patches/multiple_files.patch
+++ b/tests/testdata/test_patches/multiple_files.patch
@@ -1,0 +1,34 @@
+diff --git a/existing_file.txt b/existing_file.txt
+index 272b2e4..e90cc44 100644
+--- a/existing_file.txt
++++ b/existing_file.txt
+@@ -1,3 +1,3 @@
+ first line
+-second line
+-third line
+\ No newline at end of file
++edited second line
++edited third line
+diff --git a/existing_file_2.txt b/existing_file_2.txt
+index d0c5e43..720799f 100644
+--- a/existing_file_2.txt
++++ b/existing_file_2.txt
+@@ -1,5 +1,6 @@
+ line one
+ line two
+ line three
+-line four
++edited line four
++line five
+ line six
+\ No newline at end of file
+diff --git a/new_file.txt b/new_file.txt
+new file mode 100644
+index 0000000..fa58e34
+--- /dev/null
++++ b/new_file.txt
+@@ -0,0 +1,3 @@
++line one
++line two
++line three
+\ No newline at end of file

--- a/tests/testdata/test_patches/remove_empty_file.patch
+++ b/tests/testdata/test_patches/remove_empty_file.patch
@@ -1,0 +1,3 @@
+diff --git a/existing_empty_file.txt b/existing_empty_file.txt
+deleted file mode 100644
+index e69de29..0000000

--- a/tests/testdata/test_patches/renamed_empty_file.patch
+++ b/tests/testdata/test_patches/renamed_empty_file.patch
@@ -1,0 +1,4 @@
+diff --git a/existing_empty_file.txt b/renamed_existing_empty_file.txt
+similarity index 100%
+rename from existing_empty_file.txt
+rename to renamed_existing_empty_file.txt


### PR DESCRIPTION
Hi!

Here's the fix for the problem I stumbled upon when I was doing some experiments on running mutation tests based on git patch. The problem was `whatthepatch` library returns `None` instead of empty list as a value for `diff.changes` if file has no changes (new empty file, renamed empty file, removed empty file - tested on MacOS and Windows 10), which made mutmut to crash because of the set comprehension requirement in `__init__.py`. I tested it on current version of whatthepatch (1.0.3) and one from requirements (0.0.6), but for both versions the behaviour was the same. 

Unfortunately, not only it didn't parse the patch, but also crash `mutmut`. Therefore, I thought it would be good idea to fix it, since without it it would require for my use case to generate list of changed lines externally as a coverage report and pass it with the `--use-coverage` parameter. 

As before, I added a regression unit test suite to make sure it won't happen again. 