### PR TITLE
Allow newer versions of junit-xml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ glob2
 parso
 click
 pony
-junit-xml==1.8
+junit-xml>=1.8,<2
 toml


### PR DESCRIPTION
`junit-xml` version 1.9 provides a Wheel which is faster to install.
This is relevant for `mutmut` as well as downstream users of `mutmut`.

Please consider merging it so I could bump `junit-xml`'s version in my projects.

Thanks :) 