### PR TITLE
Use dataclasses for Config & RelativeMutationID

### DIFF
--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -800,7 +800,9 @@ def run_mutation(context: Context, callback) -> str:
             return BAD_TIMEOUT
 
         time_elapsed = time() - start
-        if not survived and time_elapsed > config.test_time_base + (config.baseline_time_elapsed * config.test_time_multipler):
+        if not survived and time_elapsed > config.test_time_base + (
+            config.baseline_time_elapsed * config.test_time_multiplier
+        ):
             return OK_SUSPICIOUS
 
         if survived:
@@ -830,7 +832,7 @@ class Config:
         self.test_command = self._default_test_command = test_command
         self.covered_lines_by_filename = covered_lines_by_filename
         self.baseline_time_elapsed = baseline_time_elapsed
-        self.test_time_multipler = test_time_multiplier
+        self.test_time_multiplier = test_time_multiplier
         self.test_time_base = test_time_base
         self.dict_synonyms = dict_synonyms
         self.total = total

--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -12,6 +12,7 @@ import sys
 import toml
 from configparser import ConfigParser
 from copy import copy as copy_obj
+from dataclasses import dataclass, field
 from functools import wraps
 from io import (
     open,
@@ -43,23 +44,12 @@ except ImportError:
     mutmut_config = None
 
 
+@dataclass(frozen=True)
 class RelativeMutationID:
-    def __init__(
-        self, line: str, index: int, line_number: int, filename: Optional[str] = None
-    ):
-        self.line = line
-        self.index = index
-        self.line_number = line_number
-        self.filename = filename
-
-    def __repr__(self):
-        return 'MutationID(line="{}", index={}, line_number={}, filename={})'.format(self.line, self.index, self.line_number, self.filename)
-
-    def __eq__(self, other):
-        return (self.line, self.index, self.line_number) == (other.line, other.index, other.line_number)
-
-    def __hash__(self):
-        return hash((self.line, self.index, self.line_number))
+    line: str
+    index: int
+    line_number: int
+    filename: Optional[str] = field(default=None, compare=False, hash=False)
 
 
 ALL = RelativeMutationID(filename='%all%', line='%all%', index=-1, line_number=-1)

--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -28,7 +28,7 @@ from threading import (
     Thread,
 )
 from time import time
-from typing import Callable, Dict, Iterator, List, Optional, Tuple
+from typing import Callable, Dict, Iterator, List, Optional, Set, Tuple
 
 from parso import parse
 from parso.python.tree import Name, Number, Keyword, FStringStart, FStringEnd
@@ -822,31 +822,31 @@ def run_mutation(context: Context, callback) -> str:
                 callback(result)
 
 
+@dataclass
 class Config:
-    def __init__(self, swallow_output, test_command, covered_lines_by_filename,
-                 baseline_time_elapsed, test_time_multiplier, test_time_base,
-                 dict_synonyms, total, using_testmon,
-                 tests_dirs, hash_of_tests, pre_mutation, post_mutation,
-                 coverage_data, paths_to_mutate, mutation_types_to_apply, no_progress, ci, rerun_all):
-        self.swallow_output = swallow_output
-        self.test_command = self._default_test_command = test_command
-        self.covered_lines_by_filename = covered_lines_by_filename
-        self.baseline_time_elapsed = baseline_time_elapsed
-        self.test_time_multiplier = test_time_multiplier
-        self.test_time_base = test_time_base
-        self.dict_synonyms = dict_synonyms
-        self.total = total
-        self.using_testmon = using_testmon
-        self.tests_dirs = tests_dirs
-        self.hash_of_tests = hash_of_tests
-        self.post_mutation = post_mutation
-        self.pre_mutation = pre_mutation
-        self.coverage_data = coverage_data
-        self.paths_to_mutate = paths_to_mutate
-        self.mutation_types_to_apply = mutation_types_to_apply
-        self.no_progress = no_progress
-        self.ci = ci
-        self.rerun_all = rerun_all
+    swallow_output: bool
+    test_command: str
+    _default_test_command: str = field(init=False)
+    covered_lines_by_filename: Optional[Dict[str, set[Optional[int]]]]
+    baseline_time_elapsed: float
+    test_time_multiplier: float
+    test_time_base: float
+    dict_synonyms: List[str]
+    total: int
+    using_testmon: bool
+    tests_dirs: List[str]
+    hash_of_tests: str
+    post_mutation: str
+    pre_mutation: str
+    coverage_data: Dict[str, Dict[int, List[str]]]
+    paths_to_mutate: List[str]
+    mutation_types_to_apply: Set[str]
+    no_progress: bool
+    ci: bool
+    rerun_all: bool
+
+    def __post_init__(self):
+        self._default_test_command = self.test_command
 
 
 def tests_pass(config: Config, callback) -> bool:

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -232,14 +232,30 @@ def html(dict_synonyms):
     sys.exit(0)
 
 
-def do_run(argument, paths_to_mutate, disable_mutation_types,
-           enable_mutation_types, runner, tests_dir, test_time_multiplier, test_time_base,
-           swallow_output, use_coverage, dict_synonyms, pre_mutation, post_mutation,
-           use_patch_file, paths_to_exclude, simple_output, no_progress, ci, rerun_all):
+def do_run(
+    argument,
+    paths_to_mutate,
+    disable_mutation_types,
+    enable_mutation_types,
+    runner,
+    tests_dir,
+    test_time_multiplier,
+    test_time_base,
+    swallow_output,
+    use_coverage,
+    dict_synonyms,
+    pre_mutation,
+    post_mutation,
+    use_patch_file,
+    paths_to_exclude,
+    simple_output,
+    no_progress,
+    ci,
+    rerun_all,
+) -> int:
     """return exit code, after performing an mutation test run.
 
     :return: the exit code from executing the mutation tests
-    :rtype: int
     """
     if use_coverage and use_patch_file:
         raise click.BadArgumentUsage("You can't combine --use-coverage and --use-patch")
@@ -434,22 +450,22 @@ def parse_run_argument(argument, config, dict_synonyms, mutations_by_file, paths
         mutations_by_file[filename] = [mutation_id]
 
 
-def time_test_suite(swallow_output, test_command, using_testmon, current_hash_of_tests, no_progress):
+def time_test_suite(
+    swallow_output: bool,
+    test_command: str,
+    using_testmon: bool,
+    current_hash_of_tests,
+    no_progress,
+) -> float:
     """Execute a test suite specified by ``test_command`` and record
     the time it took to execute the test suite as a floating point number
 
     :param swallow_output: if :obj:`True` test stdout will be not be printed
-    :type swallow_output: bool
-
     :param test_command: command to spawn the testing subprocess
-    :type test_command: str
-
     :param using_testmon: if :obj:`True` the test return code evaluation will
         accommodate for ``pytest-testmon``
-    :type using_testmon: bool
 
     :return: execution time of the test suite
-    :rtype: float
     """
     cached_time = cached_test_time()
     if cached_time is not None and current_hash_of_tests == cached_hash_of_tests():


### PR DESCRIPTION
I am adding type hints while trying to understand the code, and dataclasses made that a bit easier.

 The only changed behavior is that `repr(config)` is no longer `<__init__.Config object at ID>` and `hash(config)` is no longer `id(config)`. 
