### PR TITLE
Raise FileNotFoundError if no test dirs are found

### DIFF
--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -303,7 +303,12 @@ def do_run(
         )
 
     tests_dirs = []
-    for p in split_paths(tests_dir):
+    test_paths = split_paths(tests_dir)
+    if test_paths is None:
+        raise FileNotFoundError(
+            'No test folders found in current folder. Run this where there is a "tests" or "test" folder.'
+        )
+    for p in test_paths:
         tests_dirs.extend(glob(p, recursive=True))
 
     for p in paths_to_mutate:


### PR DESCRIPTION
Before this change, a `TypeError: 'NoneType' object is not iterable` would occur. The new exception is more helpful.