### PR TITLE
bugfix: mutmut should pick up the config before running the original test suite

### DIFF
--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -388,16 +388,16 @@ Legend for output:
         except ImportError:
             runner = 'python -m unittest'
 
+    if hasattr(mutmut_config, 'init'):
+        mutmut_config.init()
+        
     baseline_time_elapsed = time_test_suite(
         swallow_output=not swallow_output,
         test_command=runner,
         using_testmon=using_testmon,
         current_hash_of_tests=current_hash_of_tests,
         no_progress=no_progress,
-    )
-
-    if hasattr(mutmut_config, 'init'):
-        mutmut_config.init()
+    )    
 
     if using_testmon:
         copy('.testmondata', '.testmondata-initial')


### PR DESCRIPTION
**Bug**: mutmut reads the config file stored in `mutmut_config.py` only after it runs the initial set of tests. Some tests (like end-to-end, integration tests etc) can't pass without certain infrastructure and are not even supposed to be part of mutation testing process. 

As a result they fail before mutmut accesses the config file with `runner` command and mutmut can't proceed and crashes as well.

**Fix**: Reading configs prior to running initial set of tests allows to specify test suits you want to run and avoid crashes. 

**Example**: Let's say, you have unit tests in `tests/unit/` folder and you want to run only them. You can configure your `mutmut_config.py` like so:

```
from pathlib import Path


def init():
    test_files = (Path(__file__).parent / "tests/unit").rglob("test*.py")


def pre_mutation(context):
    context.config.test_command = "poetry run pytest tests/unit"
```