### PR TITLE
Normalize paths from patch file

### DIFF
--- a/mutmut/__init__.py
+++ b/mutmut/__init__.py
@@ -1220,7 +1220,7 @@ def read_patch_data(patch_file_path: str):
         diffs = whatthepatch.parse_patch(f.read())
 
     return {
-        diff.header.new_path: {change.new for change in diff.changes if change.old is None}
+        os.path.normpath(diff.header.new_path): {change.new for change in diff.changes if change.old is None}
         for diff in diffs if diff.changes
     }
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,5 @@
 
+import os
 from pathlib import Path
 from time import sleep
 from pytest import raises, fixture
@@ -132,6 +133,18 @@ def test_read_patch_data_edited_line_is_in_the_list(testpatches_path: Path):
     # arrange
     file_name = "existing_file.txt"
     file_patch = testpatches_path / "edit_existing_line.patch"
+
+    # act
+    file_changes = read_patch_data(file_patch)
+
+    # assert
+    assert file_name in file_changes
+    assert file_changes[file_name] == {2} # line is added between 2nd and 3rd
+
+def test_read_patch_data_edited_line_in_subfolder_is_in_the_list(testpatches_path: Path):
+    # arrange
+    file_name = os.path.join("sub", "existing_file.txt") # unix will use "/", windows "\" to join
+    file_patch = testpatches_path / "edit_existing_line_in_subfolder.patch"
 
     # act
     file_changes = read_patch_data(file_patch)

--- a/tests/testdata/test_patches/edit_existing_line_in_subfolder.patch
+++ b/tests/testdata/test_patches/edit_existing_line_in_subfolder.patch
@@ -1,0 +1,10 @@
+diff --git a/sub/existing_file.txt b/sub/existing_file.txt
+index 272b2e4..9767587 100644
+--- a/sub/existing_file.txt
++++ b/sub/existing_file.txt
+@@ -1,3 +1,3 @@
+ first line
+-second line
++second line is edited
+ third line
+\ No newline at end of file


### PR DESCRIPTION
os.path.join will use either "/" or "\" as path separator, depending on running host system. Patch files use UNIX separators.

Fixes #311 