### PR TITLE
Add option to html command to specify output directory

### DIFF
--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -254,14 +254,16 @@ def junitxml(dict_synonyms, suspicious_policy, untested_policy):
 
 @climain.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.option('--dict-synonyms')
+@click.option('-d', '--directory', help='Write the output files to DIR.')
 @config_from_file(
     dict_synonyms='',
+    directory='html',
 )
-def html(dict_synonyms):
+def html(dict_synonyms, directory):
     """
     Generate a HTML report of surviving mutants.
     """
-    create_html_report(dict_synonyms)
+    create_html_report(dict_synonyms, directory)
     sys.exit(0)
 
 

--- a/mutmut/cache.py
+++ b/mutmut/cache.py
@@ -260,12 +260,12 @@ def create_junitxml_report(dict_synonyms, suspicious_policy, untested_policy):
 
 @init_db
 @db_session
-def create_html_report(dict_synonyms):
+def create_html_report(dict_synonyms, directory):
     mutants = sorted(list(select(x for x in Mutant)), key=lambda x: x.line.sourcefile.filename)
 
-    os.makedirs('html', exist_ok=True)
+    os.makedirs(directory, exist_ok=True)
 
-    with open('html/index.html', 'w') as index_file:
+    with open(join(directory, 'index.html'), 'w') as index_file:
         index_file.write('<h1>Mutation testing report</h1>')
 
         index_file.write('Killed %s out of %s mutants' % (len([x for x in mutants if x.status == OK_KILLED]), len(mutants)))
@@ -273,7 +273,7 @@ def create_html_report(dict_synonyms):
         index_file.write('<table><thead><tr><th>File</th><th>Total</th><th>Skipped</th><th>Killed</th><th>% killed</th><th>Survived</th></thead>')
 
         for filename, mutants in groupby(mutants, key=lambda x: x.line.sourcefile.filename):
-            report_filename = join('html', filename)
+            report_filename = join(directory, filename)
 
             mutants = list(mutants)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -704,3 +704,16 @@ def test_html_output(surviving_mutants_filesystem):
             '<table><thead><tr><th>File</th><th>Total</th><th>Skipped</th><th>Killed</th><th>% killed</th><th>Survived</th></thead>'
             '<tr><td><a href="foo.py.html">foo.py</a></td><td>2</td><td>0</td><td>0</td><td>0.00</td><td>2</td>'
             '</table></body></html>')
+        
+def test_html_custom_output(surviving_mutants_filesystem):
+    result = CliRunner().invoke(climain, ['run', '--paths-to-mutate=foo.py', "--test-time-base=15.0"], catch_exceptions=False)
+    print(repr(result.output))
+    result = CliRunner().invoke(climain, ['html', '--directory', 'htmlmut'])
+    assert os.path.isfile("htmlmut/index.html")
+    with open("htmlmut/index.html") as f:
+        assert f.read() == (
+            '<h1>Mutation testing report</h1>'
+            'Killed 0 out of 2 mutants'
+            '<table><thead><tr><th>File</th><th>Total</th><th>Skipped</th><th>Killed</th><th>% killed</th><th>Survived</th></thead>'
+            '<tr><td><a href="foo.py.html">foo.py</a></td><td>2</td><td>0</td><td>0</td><td>0.00</td><td>2</td>'
+            '</table></body></html>')


### PR DESCRIPTION
Default directory stays "html", added "--directory" option similar to coverage package.