### PR TITLE
Add note about mutmut_config.py cache issue

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -215,6 +215,8 @@ Inversely, you can also only specify to only run specific mutations with ``--ena
 Note that ``--disable-mutation-types`` and ``--enable-mutation-types`` are exclusive and cannot
 be combined.
 
+Changes made to ``mutmut_config.py`` does not invalidate the cache.
+If you modify the configuration file, you will likely need to remove ``.mutmut-cache`` manually to ensure that the changes take effect.
 
 Selecting tests to run
 ----------------------


### PR DESCRIPTION
After spending some time troubleshooting why my new whitelist rules are not applied, I discovered that changes to mutmut_config.py don't invalidate the cache, and mutmut just returns the previous result without taking the new rules into account. Therefore, I suggest adding a note to the documentation to clarify this behavior.