### PR TITLE
Make the bash script easily copy-pasteable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,7 +158,12 @@ Mutmut keeps a result cache in ``.mutmut-cache`` so if you want to make sure you
 run a full mutmut run just delete this file.
 
 If you want to re-run all survivors after changing a lot of code or even the configuration,
-you can use `for ID in $(mutmut result-ids survived); do mutmut run $ID; done` (for bash).
+you can use the following command in a ``bash`` terminal.
+
+.. code-block:: bash
+
+    for ID in $(mutmut result-ids survived); do mutmut run $ID; done
+
 
 You can also tell mutmut to just check a single mutant:
 


### PR DESCRIPTION
Right now, the bash script to run mutations is not a code block.  There is a potential of people copy-pasting wrong thing.

When we show it as a code block, then copy-pasting is accurate and also easy.