### PR TITLE
WIP fixes to make mutmut3 work with inline-snapshot

### DIFF
--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -186,7 +186,6 @@ trampoline_impl = """
 from inspect import signature as _mutmut_signature
 
 def _mutmut_trampoline(orig, mutants, *args, **kwargs):
-    __tracebackhide__ = True 
     import os
     mutant_under_test = os.environ.get('MUTANT_UNDER_TEST',"")
     if mutant_under_test == 'fail':
@@ -333,7 +332,6 @@ def build_trampoline(*, orig_name, mutants, class_name, is_generator):
 {mutants_dict}
 
 def {orig_name}({'self, ' if class_name is not None else ''}*args, **kwargs):
-    __tracebackhide__ = True 
     result = {yield_statement}{trampoline_name}({access_prefix}{mangled_name}__mutmut_orig{access_suffix}, {access_prefix}{mangled_name}__mutmut_mutants{access_suffix}, *args, **kwargs)
     return result 
 

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -986,6 +986,8 @@ def config_reader():
             return default
         if isinstance(default, list):
             result = [x for x in result.split("\n") if x]
+        elif isinstance(default,bool):
+            result = result.lower() in ('1', 't', 'true')
         elif isinstance(default, int):
             result = int(result)
         return result
@@ -1007,7 +1009,7 @@ def read_config():
             Path('tests.py'),
         ],
         max_stack_depth=s('max_stack_depth', -1),
-        debug=s('debug', 'False').lower() in ('1', 't', 'true'),
+        debug=s('debug', False),
     )
 
 

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -128,9 +128,15 @@ def guess_paths_to_mutate():
         'Could not figure out where the code to mutate is. '
         'Please specify it on the command line using --paths-to-mutate, '
         'or by adding "paths_to_mutate=code_dir" in setup.cfg to the [mutmut] section.')
+  
+def limit_memory(maxsize): 
+    soft, hard = resource.getrlimit(resource.RLIMIT_AS) 
+    resource.setrlimit(resource.RLIMIT_AS, (maxsize, hard))
 
 
 def record_trampoline_hit(name):
+    if getattr(mutmut,"config",None) is None:
+        return
     if mutmut.config.max_stack_depth != -1:
         f = inspect.currentframe()
         c = mutmut.config.max_stack_depth
@@ -180,8 +186,9 @@ trampoline_impl = """
 from inspect import signature as _mutmut_signature
 
 def _mutmut_trampoline(orig, mutants, *args, **kwargs):
+    __tracebackhide__ = True 
     import os
-    mutant_under_test = os.environ['MUTANT_UNDER_TEST']
+    mutant_under_test = os.environ.get('MUTANT_UNDER_TEST',"")
     if mutant_under_test == 'fail':
         from mutmut.__main__ import MutmutProgrammaticFailException
         raise MutmutProgrammaticFailException('Failed programmatically')      
@@ -326,6 +333,7 @@ def build_trampoline(*, orig_name, mutants, class_name, is_generator):
 {mutants_dict}
 
 def {orig_name}({'self, ' if class_name is not None else ''}*args, **kwargs):
+    __tracebackhide__ = True 
     result = {yield_statement}{trampoline_name}({access_prefix}{mangled_name}__mutmut_orig{access_suffix}, {access_prefix}{mangled_name}__mutmut_mutants{access_suffix}, *args, **kwargs)
     return result 
 
@@ -669,10 +677,10 @@ class ListAllTestsResult:
 
     def clear_out_obsolete_test_names(self):
         count_before = sum(len(x) for x in mutmut.tests_by_mangled_function_name)
-        mutmut.tests_by_mangled_function_name = {
+        mutmut.tests_by_mangled_function_name = defaultdict(set,{
             k: {test_name for test_name in test_names if test_name in self.ids}
             for k, test_names in mutmut.tests_by_mangled_function_name.items()
-        }
+        })
         count_after = sum(len(x) for x in mutmut.tests_by_mangled_function_name)
         if count_before != count_after:
             print(f'Removed {count_before - count_after} obsolete test names')
@@ -688,6 +696,8 @@ class PytestRunner(TestRunner):
         if mutmut.config.debug:
             params = ['-vv'] + params
             print('pytest: ', params, kwargs)
+
+        params += ["--rootdir=."]
         exit_code = int(pytest.main(params, **kwargs))
         if exit_code == 4:
             raise BadTestExecutionCommandsException(params)
@@ -1097,7 +1107,7 @@ def collect_source_file_mutation_data(*, mutant_names):
         source_file_mutation_data_by_path[str(path)] = m
 
     mutants = [
-        (m, mutant_name, result)
+        (m, mutant_name.replace("src.", ""), result)
         for path, m in source_file_mutation_data_by_path.items()
         for mutant_name, result in m.exit_code_by_key.items()
     ]
@@ -1202,6 +1212,7 @@ def run(mutant_names, *, max_children):
     os.environ['MUTANT_UNDER_TEST'] = ''
     with CatchOutput(spinner_title='Running clean tests') as output_catcher:
         tests = tests_for_mutant_names(mutant_names)
+        
 
         clean_test_exit_code = runner.run_tests(mutant_name=None, tests=tests)
         if clean_test_exit_code != 0:
@@ -1257,6 +1268,7 @@ def run(mutant_names, *, max_children):
                 # In the child
                 os.environ['MUTANT_UNDER_TEST'] = mutant_name
                 setproctitle(f'mutmut: {mutant_name}')
+                limit_memory(1000*1000*500)
 
                 # Run fast tests first
                 tests = sorted(tests, key=lambda test_name: mutmut.duration_by_test[test_name])

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,3 +2,4 @@ pytest
 mock>=2.0.0
 coverage
 whatthepatch==0.0.6
+hammett


### PR DESCRIPTION
this is currently all work in progress ...

it is important that the actual inline-snapshot package is NOT part of the venv.

steps to create the venv:

... inside inline-snapshot repo using the mutmut3 branch

``` sh
python -m venv mutmut_venv
source mutmut_venv/bin/activate.sh
python -m pip install ../mutmut # my local mutmut fork
mutmut run # which will fail but copy the code
python -m pip install -r requirements.txt
mutmut run # which should work now
```

