### PR TITLE
Aannotate mutant dicts and solve Pydantic compatibility

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+Unreleased
+~~~~~~~~~~
+
+* Annotate mutant dicts (and fixes compatibility with Pydantic)
+
 3.2.3
 ~~~~~
 

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -188,6 +188,13 @@ class BadTestExecutionCommandsException(Exception):
 # language=python
 trampoline_impl = """
 from inspect import signature as _mutmut_signature
+from typing import Annotated
+from typing import Callable
+from typing import ClassVar
+
+
+MutantDict = Annotated[dict[str, Callable], "Mutant"]
+
 
 def _mutmut_trampoline(orig, mutants, *args, **kwargs):
     import os
@@ -318,7 +325,7 @@ def build_trampoline(*, orig_name, mutants, class_name, is_generator):
 
     mangled_name = mangle_function_name(name=orig_name, class_name=class_name)
 
-    mutants_dict = f'{mangled_name}__mutmut_mutants = {{\n' + ', \n    '.join(f'{repr(m)}: {m}' for m in mutants) + '\n}'
+    mutants_dict = f'{mangled_name}__mutmut_mutants : ClassVar[MutantDict] = {{\n' + ', \n    '.join(f'{repr(m)}: {m}' for m in mutants) + '\n}'
     access_prefix = ''
     access_suffix = ''
     if class_name is not None:

--- a/tests/test_mutmut3.py
+++ b/tests/test_mutmut3.py
@@ -28,7 +28,7 @@ def x_foo__mutmut_1(a, b, c):
 def x_foo__mutmut_2(a, b, c):
     return a + b / c
 
-x_foo__mutmut_mutants = {
+x_foo__mutmut_mutants : ClassVar[MutantDict] = {
 'x_foo__mutmut_1': x_foo__mutmut_1, 
     'x_foo__mutmut_2': x_foo__mutmut_2
 }
@@ -63,7 +63,7 @@ def x_foo__mutmut_orig(a: List[int]) -> int:
 def x_foo__mutmut_1(a: List[int]) -> int:
     return 2
 
-x_foo__mutmut_mutants = {
+x_foo__mutmut_mutants : ClassVar[MutantDict] = {
 'x_foo__mutmut_1': x_foo__mutmut_1
 }
 


### PR DESCRIPTION
This solves compatibility with Pydantic, as Pydantic needs every Model attribute to be typed, or annotated with ClassVar so they get ignored.

fixes #353 