### PR TITLE
copy full src dir before creating mutants

### DIFF
--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -219,6 +219,13 @@ def _mutmut_trampoline(orig, mutants, *args, **kwargs):
 """
 yield_from_trampoline_impl = trampoline_impl.replace('result = ', 'result = yield from ').replace('_mutmut_trampoline', '_mutmut_yield_from_trampoline')
 
+def copy_src_dir():
+    for root, filename in walk_all_files():
+        path = Path(root) / filename
+        print(path)
+        output_path = Path('mutants') / path
+        makedirs(output_path.parent, exist_ok=True)
+        shutil.copy(path, output_path)
 
 def create_mutants():
     for path in walk_source_files():
@@ -1230,6 +1237,7 @@ def run(mutant_names, *, max_children):
     start = datetime.now()
     makedirs(Path('mutants'), exist_ok=True)
     with CatchOutput(spinner_title='Generating mutants'):
+        copy_src_dir()
         create_mutants()
         copy_also_copy_files()
 

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -261,10 +261,6 @@ def pragma_no_mutate_lines(source):
 def create_mutants_for_file(filename, output_path):
     input_stat = os.stat(filename)
 
-    # if output_path.exists() and output_path.stat().st_mtime == input_stat.st_mtime:
-    #     # print('    skipped', output_path, 'already up to date')
-    #     return
-
     with open(filename) as f:
         source = f.read()
 
@@ -1375,8 +1371,7 @@ def run(mutant_names, *, max_children):
 
     print_stats(source_file_mutation_data_by_path, force_output=True)
     print()
-    print(f'    done in {round(t.total_seconds()*1000)}ms')
-    print(f'    {count_tried / t.total_seconds():.2f} mutations/second')
+    print(f'{count_tried / t.total_seconds():.2f} mutations/second')
 
     if mutant_names:
         print()

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -220,12 +220,9 @@ def _mutmut_trampoline(orig, mutants, *args, **kwargs):
 yield_from_trampoline_impl = trampoline_impl.replace('result = ', 'result = yield from ').replace('_mutmut_trampoline', '_mutmut_yield_from_trampoline')
 
 def copy_src_dir():
-    for root, filename in walk_all_files():
-        path = Path(root) / filename
-        print(path)
+    for path in mutmut.config.paths_to_mutate:
         output_path = Path('mutants') / path
-        makedirs(output_path.parent, exist_ok=True)
-        shutil.copy(path, output_path)
+        shutil.copytree(path, output_path, dirs_exist_ok=True)
 
 def create_mutants():
     for path in walk_source_files():
@@ -264,9 +261,9 @@ def pragma_no_mutate_lines(source):
 def create_mutants_for_file(filename, output_path):
     input_stat = os.stat(filename)
 
-    if output_path.exists() and output_path.stat().st_mtime == input_stat.st_mtime:
-        # print('    skipped', output_path, 'already up to date')
-        return
+    # if output_path.exists() and output_path.stat().st_mtime == input_stat.st_mtime:
+    #     # print('    skipped', output_path, 'already up to date')
+    #     return
 
     with open(filename) as f:
         source = f.read()
@@ -1378,7 +1375,8 @@ def run(mutant_names, *, max_children):
 
     print_stats(source_file_mutation_data_by_path, force_output=True)
     print()
-    print(f'{count_tried / t.total_seconds():.2f} mutations/second')
+    print(f'    done in {round(t.total_seconds()*1000)}ms')
+    print(f'    {count_tried / t.total_seconds():.2f} mutations/second')
 
     if mutant_names:
         print()


### PR DESCRIPTION
The current process only copies python files but tests might rely on other files that exist within the src directories in a repo. This PR copies the full src directories first, creates and overwrites the files with the mutants and then copies the files specified in `also_copy`

fixes #371 