### PR TITLE
Mutation fixes

### DIFF
--- a/tests/test_mutmut3.py
+++ b/tests/test_mutmut3.py
@@ -34,7 +34,7 @@ x_foo__mutmut_mutants : ClassVar[MutantDict] = {
 }
 
 def foo(*args, **kwargs):
-    result = _mutmut_trampoline(x_foo__mutmut_orig, x_foo__mutmut_mutants, *args, **kwargs)
+    result = _mutmut_trampoline(x_foo__mutmut_orig, x_foo__mutmut_mutants, args, kwargs)
     return result 
 
 foo.__signature__ = _mutmut_signature(x_foo__mutmut_orig)
@@ -68,7 +68,7 @@ x_foo__mutmut_mutants : ClassVar[MutantDict] = {
 }
 
 def foo(*args, **kwargs):
-    result = _mutmut_trampoline(x_foo__mutmut_orig, x_foo__mutmut_mutants, *args, **kwargs)
+    result = _mutmut_trampoline(x_foo__mutmut_orig, x_foo__mutmut_mutants, args, kwargs)
     return result 
 
 foo.__signature__ = _mutmut_signature(x_foo__mutmut_orig)


### PR DESCRIPTION
While testing I found two errors in the mutation setup:

The same-args bug only occurs when calling methods with the keywords `orig` or `mutants`. e.g. if `foo(orig=123)` was called somewhere. This already fails at the clean test run, so nobody reporting it as an issue seems like no one uses these kwargs. I only noticed when running mutmut on mutmut self.

The self-parameter bug killed all class method mutations, because the mutations did not receive `self` as an argument and are not bound to any class instance. Unluckily, it worked for the original method, because the original method is passed as a bound method and does not require `self` to be passed as an argument, so the clean tests run did not notice this error. Fixing this bug will result in a decent amount of new survived mutants for projects that use classes.

The commit messages contain more details. For the self-parameter bug, I will submit an E2E snapshot test in the next days that would detect a regression that accidentally introduces it again.