### PR TITLE
Windows support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,13 +4,13 @@ on: [push, pull_request]
 
 jobs:
   tests:
-    name: Test Python ${{ matrix.python-version }}
-    # Todo: Revert to ubuntu-latest when Python 3.7 support no longer needed
-    runs-on: ubuntu-22.04
+    name: Test ${{ matrix.os }} - ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.13", "3.12", "3.11", "3.10", "3.9"]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/e2e_projects/config/pyproject.toml
+++ b/e2e_projects/config/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
 ]
 
 [tool.mutmut]
-debug = true
+debug = false
 paths_to_mutate = [ "config_pkg/" ]
 do_not_mutate = [ "*ignore*" ]
 also_copy = [ "data" ]

--- a/e2e_projects/config/tests/test_main.py
+++ b/e2e_projects/config/tests/test_main.py
@@ -21,6 +21,6 @@ def test_max_stack_depth():
 def test_data_exists():
     path = (Path("data") / "data.json").resolve()
     assert path.exists()
-    with open(path) as f:
+    with open(path, encoding='utf-8') as f:
         data = json.load(f)
         assert data['comment'] == 'this should be copied to the mutants folder'

--- a/e2e_projects/my_lib/pyproject.toml
+++ b/e2e_projects/my_lib/pyproject.toml
@@ -17,4 +17,4 @@ dev = [
 ]
 
 [tool.mutmut]
-debug = true
+debug = false

--- a/mutmut/custom_process_pool.py
+++ b/mutmut/custom_process_pool.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from typing import Generic, Union, Any, Callable, Iterable, TypeVar
+from typing_extensions import ParamSpec
+from dataclasses import dataclass
+
+import multiprocessing.connection
+from multiprocessing import Queue, Process
+import queue
+import os
+
+
+TaskArgs = ParamSpec('TaskArgs')
+TaskResult = TypeVar('TaskResult')
+
+@dataclass
+class Task:
+    id: str
+    args: tuple[Any, ...]
+    # this timeout is real time, not process cpu time
+    timeout_seconds: int
+
+@dataclass
+class TaskError:
+    id: str
+    error: Exception
+
+@dataclass
+class FinishedTask(Generic[TaskResult]):
+    id: str
+    result: Union[TaskResult, None]
+    error: Union[Exception, None]
+
+class JobTimeoutException(Exception):
+    pass
+
+class CustomProcessPool(Generic[TaskArgs, TaskResult]):
+    def __init__(self, tasks: list[Task], job: Callable[TaskArgs, TaskResult], max_workers: int):
+        self._tasks = tasks
+        self._job = job
+        self._remaining_tasks_queue: Queue[Task] = Queue()
+        self._remaining_tasks_count = len(tasks)
+        self._results: Queue[FinishedTask[TaskResult]] = Queue()
+        self._max_workers = max_workers
+        self._workers: set[Process] = set()
+        self._killed_workers = 0
+        self._shutdown = False
+
+    def run(self) -> Iterable[FinishedTask]:
+        for task in self._tasks:
+            self._remaining_tasks_queue.put(task)
+
+        self._start_missing_workers()
+
+        while not self.done() and not self._shutdown:
+            self._remove_stopped_workers()
+            self._start_missing_workers()
+
+            yield from self._get_new_results(timeout=1)
+
+        self.shutdown()
+
+    def shutdown(self):
+        # TODO: is this a good way to shutdown processes?
+        for p in self._workers:
+            if p.is_alive():
+                p.kill()
+        for p in self._workers:
+            p.join()
+        self._remaining_tasks_queue.close()
+        self._results.close()
+        self._shutdown = True
+
+    def _start_missing_workers(self):
+        self._workers = {p for p in self._workers if p.is_alive()}
+
+        desired_workers = min(self._max_workers, self._remaining_tasks_count)
+        missing_workers = desired_workers - len(self._workers)
+
+        for _ in range(missing_workers):
+            self._start_worker()
+
+    def _remove_stopped_workers(self):
+        """Start a new worker for all stopped workers. We kill workers for timeouts."""
+        killed_workers = {p for p in self._workers if not p.is_alive()}
+        self._workers -= killed_workers
+
+        for worker in killed_workers:
+            print(f'Worker {worker.pid} stopped with exitcode {worker.exitcode}')
+
+    def _get_new_results(self, timeout: int) -> Iterable[FinishedTask]:
+        try:
+            result = self._results.get(timeout=timeout)
+            self._remaining_tasks_count -= 1
+            yield result
+        except queue.Empty:
+            pass
+
+    def _start_worker(self):
+        p = Process(target=CustomProcessPool._pool_job_executor, args=(self._job, self._remaining_tasks_queue, self._results))
+        p.start()
+        self._workers.add(p)
+
+    def done(self) -> bool:
+        return self._remaining_tasks_count == 0
+
+    @staticmethod
+    def _pool_job_executor(job: Callable[..., TaskResult], task_queue: Queue[Task], results: Queue[FinishedTask[TaskResult]]):
+        while True:
+            try:
+                task = task_queue.get(timeout=1)
+                # f = open(f'logs/log-{task.id}.txt', 'w')
+                # pid = os.getpid()
+            except queue.Empty:
+                os._exit(0)
+
+            try:
+                result = job(task)
+                finished_task: FinishedTask[TaskResult] = FinishedTask(id=task.id, result=result, error=None)
+            except Exception as e:
+                finished_task = FinishedTask(id=task.id, result=None, error=e)
+            finally:
+                # f.write(f'Finished job: {finished_task}\n')
+                # f.flush()
+                results.put(finished_task)
+                # f.write(f'Added job to queue\n')
+                # f.write(f'Finished qsize: {results.qsize()}\n')
+                # f.flush()
+
+
+

--- a/mutmut/file_mutation.py
+++ b/mutmut/file_mutation.py
@@ -176,6 +176,8 @@ def combine_mutations_to_source(module: cst.Module, mutations: Sequence[Mutation
     :param mutations: Mutations that should be applied.
     :return: Mutated code and list of mutation names"""
 
+    # mutations = mutations[0:10]
+
     # copy start of the module (in particular __future__ imports)
     result: list[MODULE_STATEMENT] = get_statements_until_func_or_class(module.body)
     mutation_names: list[str] = []

--- a/tests/e2e/test_e2e_result_snapshots.py
+++ b/tests/e2e/test_e2e_result_snapshots.py
@@ -78,3 +78,6 @@ def test_my_lib_result_snapshot():
 def test_config_result_snapshot():
     mutmut._reset_globals()
     asserts_results_did_not_change("config")
+
+if __name__ == '__main__':
+    test_my_lib_result_snapshot()

--- a/tests/e2e/test_e2e_result_snapshots.py
+++ b/tests/e2e/test_e2e_result_snapshots.py
@@ -29,18 +29,18 @@ def read_all_stats_for_project(project_path: Path) -> dict[str, dict]:
                 continue
             data = SourceFileMutationData(path=p)
             data.load()
-            stats[str(data.meta_path)] = data.exit_code_by_key
+            stats[str(data.meta_path.as_posix())] = data.exit_code_by_key
 
         return stats
 
 
 def read_json_file(path: Path):
-    with open(path, 'r') as file:
+    with open(path, 'r', encoding='utf-8') as file:
         return json.load(file)
 
 
 def write_json_file(path: Path, data: Any):
-    with open(path, 'w') as file:
+    with open(path, 'w', encoding='utf-8') as file:
         json.dump(data, file, indent=2)
 
 

--- a/tests/test_custom_pool.py
+++ b/tests/test_custom_pool.py
@@ -1,0 +1,31 @@
+from mutmut.__main__ import CustomProcessPool, Task
+import pytest
+import time
+
+def test_custom_process_pool():
+    tasks = [
+        Task(id='a-small', args=(1, 2), timeout_seconds=1000),
+        Task(id='b-medium', args=(30, 20), timeout_seconds=1000),
+        Task(id='c-neg', args=(-2, -2), timeout_seconds=1000),
+        Task(id='d-div-by-zero', args=(-2, 0), timeout_seconds=1000),
+    ]
+    pool = CustomProcessPool(tasks, _divide, max_workers=2)
+
+    results = []
+    for result in pool.run():
+        print(result)
+        results.append(result)
+
+    assert len(results) == 4
+
+    results = sorted(results, key=lambda result: result.id)
+    assert results[0].result == pytest.approx(0.5)
+    assert results[1].result == pytest.approx(1.5)
+    assert results[2].result == pytest.approx(1)
+    assert results[3].result == None
+    assert isinstance(results[3].error, ZeroDivisionError)
+
+def _divide(task: Task):
+    a, b = task.args
+    # time.sleep(timeout)
+    return a / b


### PR DESCRIPTION
Refactor the code to also support windows. Closes #397 

This is still a WIP. If anyone wants to finish this PR, feel free to leave a comment and take it over :)
I probably won't get much free time in the next weeks, but wanted to share the current status.

## Implementation idea

The main tasks to support Windows are (1) to support the `spawn` method and (2) to support timeouts properly (if possible).

When directly using the `spawn` method it is much slower, because we need to startup everything from scratch for each mutant. This includes the python interpreter (I think) and the whole pytest test collection (ie importing the system under test).

To improve this performance, we only create `max_children` processes as "workers". These workers infinitely loop on:
1. pick the next mutant from a shared queue
2. test the mutant
3. return the result
4. repeat at (1) until the queue is empty

As such we only need to setup a limited number of processes, instead of one per mutant. To support timeouts (where we likely still want to kill processes), we need to restart workers when they time out.

## TODO

- [x] support `spawn` method by passing all globals as args to the new processes
- [x] use a process pool to increase performance (when we reuse the processes, pytest caches all the imported files)
- [x] add Windows tests to CI
- [ ] Reimplement timeouts (I've removed them for now for simplicity)
- [ ] Debug why this branch outputs slightly different results than on main
- [ ] Test on other repos
- [ ] Cleanup

### Implementing timeouts

Previously we used `resource` to implement timeouts: https://github.com/boxed/mutmut/blob/f63029b239fa7c8042b2a45c5191674df419cd31/mutmut/__main__.py#L1009-L1011

And also a timeout checker thread (which I assume is only the backup in case `resource` does not work): https://github.com/boxed/mutmut/blob/f63029b239fa7c8042b2a45c5191674df419cd31/mutmut/__main__.py#L864-L878

Windows does not support `resource` so maybe we need to only use `resource` on Linux and the timeout checker on Windows.

Also, we now reuse processes. So when killing a long-running process we need to ensure that we restart that worker, and that we report it as timeouted. The restarting *should* already work with the current implementation. But it is not reported as a result. So we likely need to track which process starts which task and then in `_remove_stopped_workers` we need to map the killed processes to the tasks they were executing, and report them as timed out (depending on the exit code).

Also note that I think mutmut reports the timeouted mutant as "killed" accidentally (I did not make a MRE yet, but it seems like it).

### Debugging different results

I've tested it on https://github.com/TOD-theses/traces_parser with a `# pragma: no mutate` on these lines (they would run into an infinite loop as we have no timeout yet): https://github.com/TOD-theses/traces_parser/blob/49d0b9cbc6fad490bba1f8a3136b24cd964336e1/traces_parser/parser/storage/memory.py#L35-L36

The main branch of mutmut outputted slightly different results than this windows-support branch of mutmut. I am not yet sure if this is due to some kind of race condition, or if it is deterministic. Maybe adding some additional logs would be useful to debug this.