### PR TITLE
Tweak spin titles under debug

### DIFF
--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -627,6 +627,8 @@ class CatchOutput:
     def __init__(self, callback=lambda s: None, spinner_title=None):
         self.strings = []
         self.spinner_title = spinner_title or ''
+        if mutmut.config is not None and mutmut.config.debug:
+            self.spinner_title += '\n'
 
         class StdOutRedirect(TextIOBase):
             def __init__(self, catcher):


### PR DESCRIPTION
I only really noticed this when reporting #419  , the bits in question being:

```
⠹ Running clean testspython -m pytest  -vv -x -q Tests/ --rootdir=.
```

and

```
⠸ Running forced fail testpython -m pytest  -vv -x -q Tests/ --rootdir=.
```

After more debug runs, I saw similar issues happened for `Generating mutants` , `Listing all tests` and `Running stats`.

This PR should be quite simple to understand - the current status quo prevails when `mutmut.config` is not set or `mutmut.config.debug` is False, but when it's True, append a newline to the spinner title in question so the next line of output starts _on the next line_, rather than appended to the end of the spinner title.

Checking `mutmut.config is None` first obviates the NoneType reference error that would otherwise occur - eg in mocked tests.