### PR TITLE
Bail out of stack traversal when hitting unittest files

### DIFF
--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -137,7 +137,8 @@ def record_trampoline_hit(name):
         f = inspect.currentframe()
         c = mutmut.config.max_stack_depth
         while c and f:
-            if 'pytest' in f.f_code.co_filename or 'hammett' in f.f_code.co_filename:
+            filename = f.f_code.co_filename
+            if 'pytest' in filename or 'hammett' in filename or 'unittest' in filename:
                 break
             f = f.f_back
             c -= 1


### PR DESCRIPTION
As at the status quo, stack traversal terminates when hitting a file with 'pytest' or 'hammett' in the path, but blithely carries on if a file has 'unittest' in the path, despite that being the unittest framework.

The simple fix to that is to also bail out if 'unittest' is in the current frame's filename.