### PR TITLE
fix typos warnings

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -41,7 +41,7 @@ Codebases using Poetry
 .. code-block:: console
 
     poetry add --group dev --editable <path_to_mutmut_codebase>
-    # Install dependecies in your Poetry environment
+    # Install dependencies in your Poetry environment
     pip install -r <path_to_mutmut_codebase>/requirements.txt
 
 Documentation about mutmut's architecture

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -143,7 +143,7 @@ Changelog
 3.0.0
 ~~~~~
 
-* Execution model switched to mutation schemata, which enabled parallell execution.
+* Execution model switched to mutation schemata, which enabled parallel execution.
 
 * New terminal UI
 

--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -925,7 +925,7 @@ set_start_method('fork')
 START_TIMES_BY_PID_LOCK = Lock()
 
 def timeout_checker(mutants):
-    def inner_timout_checker():
+    def inner_timeout_checker():
         while True:
             sleep(1)
 
@@ -941,7 +941,7 @@ def timeout_checker(mutants):
                             os.kill(pid, signal.SIGXCPU)
                         except ProcessLookupError:
                             pass
-    return inner_timout_checker
+    return inner_timeout_checker
 
 
 @cli.command()

--- a/mutmut/file_mutation.py
+++ b/mutmut/file_mutation.py
@@ -274,7 +274,7 @@ def pragma_no_mutate_lines(source: str) -> set[int]:
     }
 
 def deep_replace(tree: cst.CSTNode, old_node: cst.CSTNode, new_node: cst.CSTNode) -> cst.CSTNode:
-    """Like the CSTNode.deep_replace method, except that we only replace up to one occurence of old_node."""
+    """Like the CSTNode.deep_replace method, except that we only replace up to one occurrence of old_node."""
     return tree.visit(ChildReplacementTransformer(old_node, new_node)) # type: ignore
 
 class ChildReplacementTransformer(cst.CSTTransformer):

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -118,7 +118,7 @@ def mutated_module(source: str) -> str:
             'lambda **kwargs: Variable.integer(**setdefaults(kwargs, None))',
             'lambda **kwargs: Variable.integer(**setdefaults(kwargs, ))',
             'lambda **kwargs: Variable.integer(**setdefaults(dict(show=False)))',
-            # TODO: this mutant would exist if we also mutate single-arg arglists (see implentation)
+            # TODO: this mutant would exist if we also mutate single-arg arglists (see implementation)
             # 'lambda **kwargs: Variable.integer()',
             'lambda **kwargs: None',
         ]),


### PR DESCRIPTION
Hello.
In this pr i've corrected a few warnings https://github.com/crate-ci/typos.

Fixed warnings

```
(.venv) ➜  mutmut git:(fix_typos_warnings) ✗ typos .                           

error: `parallell` should be `parallel`
  --> ./HISTORY.rst:146:64
    |
146 | * Execution model switched to mutation schemata, which enabled parallell execution.
    |                                                                ^^^^^^^^^
    |
error: `dependecies` should be `dependencies`
  --> ./CONTRIBUTING.rst:44:15
   |
44 |     # Install dependecies in your Poetry environment
   |               ^^^^^^^^^^^
   |
error: `implentation` should be `implementation`
  --> ./tests/test_mutation.py:121:88
    |
121 |             # TODO: this mutant would exist if we also mutate single-arg arglists (see implentation)
    |                                                                                        ^^^^^^^^^^^^
    |

error: `timout` should be `timeout`
  --> ./mutmut/__main__.py:928:15
    |
928 |     def inner_timout_checker():
    |               ^^^^^^
    |
error: `timout` should be `timeout`
  --> ./mutmut/__main__.py:944:18
    |
944 |     return inner_timout_checker
    |                  ^^^^^^
    |

error: `occurence` should be `occurrence`
  --> ./mutmut/file_mutation.py:277:84
    |
277 |     """Like the CSTNode.deep_replace method, except that we only replace up to one occurence of old_node."""
    |                                                                                    ^^^^^^^^^
    |
```