### PR TITLE
fix some ruff warnings in tests files

### DIFF
--- a/tests/e2e/test_cli_version.py
+++ b/tests/e2e/test_cli_version.py
@@ -1,6 +1,8 @@
+from click.testing import CliRunner
+
 from mutmut import __version__
 from mutmut.__main__ import cli
-from click.testing import CliRunner
+
 
 def test_cli_version():
     result = CliRunner().invoke(cli, ["--version"])

--- a/tests/e2e/test_e2e_result_snapshots.py
+++ b/tests/e2e/test_e2e_result_snapshots.py
@@ -11,7 +11,7 @@ from mutmut.__main__ import SourceFileMutationData, _run, ensure_config_loaded, 
 
 @contextmanager
 def change_cwd(path):
-    old_cwd = os.path.abspath(os.getcwd())
+    old_cwd = Path(Path.cwd()).resolve()
     os.chdir(path)
     try:
         yield

--- a/tests/e2e/test_e2e_result_snapshots.py
+++ b/tests/e2e/test_e2e_result_snapshots.py
@@ -1,11 +1,12 @@
-from contextlib import contextmanager
 import json
 import os
-from pathlib import Path
 import shutil
+from contextlib import contextmanager
+from pathlib import Path
 from typing import Any
+
 import mutmut
-from mutmut.__main__ import _run, walk_source_files, SourceFileMutationData, ensure_config_loaded
+from mutmut.__main__ import SourceFileMutationData, _run, ensure_config_loaded, walk_source_files
 
 
 @contextmanager
@@ -25,7 +26,7 @@ def read_all_stats_for_project(project_path: Path) -> dict[str, dict]:
 
         stats = {}
         for p in walk_source_files():
-            if mutmut.config.should_ignore_for_mutation(p): # type: ignore
+            if mutmut.config.should_ignore_for_mutation(p):  # type: ignore
                 continue
             data = SourceFileMutationData(path=p)
             data.load()

--- a/tests/test_generation_error_handling.py
+++ b/tests/test_generation_error_handling.py
@@ -1,16 +1,20 @@
-from pathlib import Path
-from mutmut.__main__ import create_mutants, Config, InvalidGeneratedSyntaxException
-import mutmut.__main__
-import mutmut
-import pytest
 import os
+from pathlib import Path
+
+import pytest
+
+import mutmut
+import mutmut.__main__
+from mutmut.__main__ import InvalidGeneratedSyntaxException, create_mutants
 
 source_dir = Path(__file__).parent / 'data' / 'test_generation'
 source_dir = source_dir.relative_to(os.getcwd())
 
+
 class MockConfig:
     def should_ignore_for_mutation(self, path: Path) -> bool:
         return False
+
 
 def test_mutant_generation_raises_exception_on_invalid_syntax(monkeypatch):
     mutmut._reset_globals()

--- a/tests/test_generation_error_handling.py
+++ b/tests/test_generation_error_handling.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import pytest
@@ -8,7 +7,7 @@ import mutmut.__main__
 from mutmut.__main__ import InvalidGeneratedSyntaxException, create_mutants
 
 source_dir = Path(__file__).parent / 'data' / 'test_generation'
-source_dir = source_dir.relative_to(os.getcwd())
+source_dir = source_dir.relative_to(Path.cwd())
 
 
 class MockConfig:

--- a/tests/test_mutmut3.py
+++ b/tests/test_mutmut3.py
@@ -1,5 +1,6 @@
-from mutmut.trampoline_templates import trampoline_impl
 from mutmut.file_mutation import mutate_file_contents
+from mutmut.trampoline_templates import trampoline_impl
+
 
 def mutated_module(source: str) -> str:
     mutated_code, _ = mutate_file_contents('', source)


### PR DESCRIPTION
Hello!

I used https://github.com/astral-sh/ruff in mutmut and I want to fix some warnings)))

In tests files:
1) Delete twice check       ('import foo', []), 
2) sorting imports https://docs.astral.sh/ruff/rules/unsorted-imports/
3) change is to == https://docs.astral.sh/ruff/rules/is-literal/
4) use list comprehension https://docs.astral.sh/ruff/rules/manual-list-comprehension/
5) change unused err to "_"
6) move some os to pathlib https://docs.astral.sh/ruff/rules/os-path-abspath