### PR TITLE
Handle -9 PyTest return code

### DIFF
--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -84,6 +84,7 @@ status_by_exit_code = {
     152: 'timeout',  # SIGXCPU
     255: 'timeout',
     -11: 'segfault',
+    -9: 'segfault',
 }
 
 emoji_by_status = {


### PR DESCRIPTION
This was more than a little weird - I was consistently getting a KeyError on line 589 of collect_stat, which maps return codes to a mutmut status.

More digging into the underlying boomage revealed the mutant that caused it, along with the tests that rumbled it.  For whatever reason, the process was getting killed _but not segfaulting_.  This manifested as a -9 return code, and thus kaboom in collect_stat.

To avoid generating another mutant status, and because "segfault" is the least-worst match, map the newly-problematic return code to "segfault".