### PR TITLE
Double speed by using native traceback formatting

### DIFF
--- a/mutmut/__main__.py
+++ b/mutmut/__main__.py
@@ -432,7 +432,7 @@ class PytestRunner(TestRunner):
     # noinspection PyMethodMayBeStatic
     def execute_pytest(self, params: list[str], **kwargs):
         import pytest
-        params = ['--rootdir=.'] + params + self._pytest_add_cli_args
+        params = ['--rootdir=.', '--tb=native'] + params + self._pytest_add_cli_args
         if mutmut.config.debug:
             params = ['-vv'] + params
             print('python -m pytest ', ' '.join([f'"{param}"' for param in params]))


### PR DESCRIPTION
In a project of mine `mutmut run` now takes half the time (instead of 70s now at 35s). In the case of #433 , executing pytest for some mutants now takes 0.x seconds instead of 10 seconds.

Pytest traceback formatting is apparently slow for large files*, so this is a bottleneck with the mutated source code.

This PR changes it to use the native traceback formatter, which takes practically no time.

I thought about keeping the pytest traceback formatter in debug mode, but given the huge performance issue, I think the default python traceback needs to suffice.

Fixes #433 


\* I did not investigate, if large files alone are enough. Probably it's about large classes, or stack traces with many variables.