### PR TITLE
Add support for f-string and concatenated string mutations

### DIFF
--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -154,6 +154,13 @@ def mutated_module(source: str) -> str:
         ('"FoO"', ['"XXFoOXX"', '"foo"', '"FOO"']),
         ("'FoO'", ["'XXFoOXX'", "'foo'", "'FOO'"]),
         ("u'FoO'", ["u'XXFoOXX'", "u'foo'", "u'FOO'"]),
+        # f-strings - mutate the first non-empty text part
+        ('f"Hello {name}"', ['f"XXHello XX{name}"', 'f"hello {name}"', 'f"HELLO {name}"']),
+        ('f"Hello {x} World"', ['f"XXHello XX{x} World"', 'f"hello {x} World"', 'f"HELLO {x} World"']),
+        ('f"{x} World"', ['f"{x}XX WorldXX"', 'f"{x} world"', 'f"{x} WORLD"']),
+        ('f"{x}{y}"', []),  # no text parts to mutate
+        # concatenated strings - currently mutates all parts
+        ('"Hello " "World"', ['"XXHello XX" "World"', '"hello " "World"', '"HELLO " "World"', '"Hello " "XXWorldXX"', '"Hello " "world"', '"Hello " "WORLD"']),
         ("10", "11"),
         ("10.", "11.0"),
         ("0o10", "9"),


### PR DESCRIPTION
Closes #439

This PR extends mutmut's string mutation capabilities to handle f-strings and concatenated strings.

## Changes

- Extended `operator_string()` in `mutmut/node_mutation.py` to mutate `FormattedString` (f-strings) and `ConcatenatedString` nodes
- F-strings now mutate the first non-empty `FormattedStringText` part with the same three mutations applied to regular strings:
  - Add "XX" prefix and suffix
  - Convert to lowercase
  - Convert to uppercase
- Whitespace preservation ensures mutations don't break Python syntax
- Concatenated strings are mutated through their individual string components by the existing visitor pattern
- Added comprehensive test coverage in `tests/test_mutation.py` for various f-string patterns
- Regenerated E2E test snapshots to reflect the new mutations

## Test Coverage

Added tests for:
- F-strings with single expressions: `f"Hello {name}"`
- F-strings with multiple expressions: `f"Hello {x} World"`
- F-strings with leading expressions: `f"{x} World"`
- F-strings with only expressions (no text to mutate): `f"{x}{y}"`
- Concatenated strings: `"Hello " "World"`

All existing tests continue to pass.