### PR TITLE
Save mutation stats for use with CI/CD pipeline

### DIFF
--- a/src/mutmut/__main__.py
+++ b/src/mutmut/__main__.py
@@ -914,6 +914,36 @@ def save_cicd_stats(source_file_mutation_data_by_path):
             segfault=s.segfault
         ), f, indent=4)
 
+# exports CI/CD stats to block pull requests from merging if mutation score is too low, or used in other ways in CI/CD pipelines
+@cli.command()
+def export_cicd_stats():
+    ensure_config_loaded()
+
+    source_file_mutation_data_by_path: Dict[str, SourceFileMutationData] = {}
+
+    for path in walk_source_files():
+        if mutmut.config.should_ignore_for_mutation(path):
+            continue
+
+        meta_path = Path('mutants') / (str(path) + '.meta')
+        if not meta_path.exists():
+            continue
+
+        m = SourceFileMutationData(path=path)
+        m.load()
+        if not m.exit_code_by_key:
+            continue
+
+        source_file_mutation_data_by_path[str(path)] = m
+
+    if not source_file_mutation_data_by_path:
+        print('No previous mutation data found. Run "mutmut run" first.')
+        return
+
+    save_cicd_stats(source_file_mutation_data_by_path)
+    print('Saved CI/CD stats to mutants/mutmut-cicd-stats.json')
+
+
 def collect_source_file_mutation_data(*, mutant_names):
     source_file_mutation_data_by_path: Dict[str, SourceFileMutationData] = {}
 
@@ -1165,9 +1195,6 @@ def _run(mutant_names: Union[tuple, list], max_children: Union[None, int]):
     print_stats(source_file_mutation_data_by_path, force_output=True)
     print()
     print(f'{count_tried / t.total_seconds():.2f} mutations/second')
-
-    # save stats so CI/CD pipelines can optionally take action
-    save_cicd_stats(source_file_mutation_data_by_path)
 
     if mutant_names:
         print()


### PR DESCRIPTION
This is a simple to change to save mutation stats after printing them so a CI/CD pipeline can optionally take action on the results.

Use case:
If mutation score is below a threshold, I want to block PR's from being merged and/or blocked a pipeline from advancing to the next stage.

Just testing the waters to see if you would be open to this change.  I read your contribution guidelines and didn't see anything that would make this an auto rejection.