### PR TITLE
Support signatures with PEP 649 deferred annotations

### DIFF
--- a/e2e_projects/my_lib/src/my_lib/__init__.py
+++ b/e2e_projects/my_lib/src/my_lib/__init__.py
@@ -97,3 +97,17 @@ def create_a_segfault_when_mutated():
     # when we mutate False->True, then this will segfault
     if False:
         ctypes.string_at(0)
+
+def some_func_clone(a, b: str = "111", c: Callable[[str], int] | None = None) -> int | None: pass  # pragma: no mutate
+def some_func(a, b: str = "111", c: Callable[[str], int] | None = None) -> int | None:
+    if a and c:
+        return c(b)
+    return None
+
+def func_with_star_clone(a, *, b, **kwargs): pass  # pragma: no mutate
+def func_with_star(a, *, b, **kwargs):
+    return a + b + len(kwargs)
+
+def func_with_arbitrary_args_clone(*args, **kwargs): pass  # pragma: no mutate
+def func_with_arbitrary_args(*args, **kwargs):
+    return len(args) + len(kwargs)

--- a/e2e_projects/my_lib/tests/test_my_lib.py
+++ b/e2e_projects/my_lib/tests/test_my_lib.py
@@ -1,4 +1,5 @@
-from my_lib import hello, Point, badly_tested, make_greeter, fibonacci, cached_fibonacci, escape_sequences, simple_consumer, async_consumer, create_a_segfault_when_mutated
+import inspect
+from my_lib import *
 import pytest
 
 """These tests are flawed on purpose, some mutants survive and some are killed."""
@@ -47,3 +48,17 @@ async def test_async_consumer():
 
 def test_handles_segfaults():
     create_a_segfault_when_mutated()
+
+def test_that_signatures_are_preserved():
+    assert inspect.signature(some_func) == inspect.signature(some_func_clone)
+    assert inspect.signature(func_with_star) == inspect.signature(func_with_star_clone)
+    assert inspect.signature(func_with_arbitrary_args) == inspect.signature(func_with_arbitrary_args_clone)
+
+    assert inspect.get_annotations(some_func) == inspect.get_annotations(some_func_clone)
+    assert inspect.get_annotations(func_with_star) == inspect.get_annotations(func_with_star_clone)
+    assert inspect.get_annotations(func_with_arbitrary_args) == inspect.get_annotations(func_with_arbitrary_args_clone)
+
+def test_signature_functions_are_callable():
+    assert some_func(True, c=lambda s: int(s), b="222") == 222
+    assert func_with_star(1, b=2, x='x', y='y', z='z') == 6
+    assert func_with_arbitrary_args('a', 'b', foo=123, bar=456) == 4

--- a/e2e_projects/py3_14_features/README.md
+++ b/e2e_projects/py3_14_features/README.md
@@ -1,0 +1,1 @@
+This project will be E2E tested. It mainly serves as a "canary" that alerts you when code changes affect which mutants survive.

--- a/e2e_projects/py3_14_features/pyproject.toml
+++ b/e2e_projects/py3_14_features/pyproject.toml
@@ -1,0 +1,23 @@
+[project]
+name = "py3-14-features"
+version = "0.1.0"
+description = "Add your description here"
+readme = "README.md"
+authors = []
+requires-python = ">=3.14"
+dependencies = []
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.3.5",
+]
+
+[tool.mutmut]
+debug = true
+
+[tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"

--- a/e2e_projects/py3_14_features/src/py3_14_features/__init__.py
+++ b/e2e_projects/py3_14_features/src/py3_14_features/__init__.py
@@ -1,0 +1,23 @@
+from typing import TYPE_CHECKING
+from dataclasses import dataclass
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
+
+# verify that mutmut can handle type-check-only annotations
+def get_len(data: Collection):
+    # (the + 0 is just so we get a surviving and a killed mutant; not relevant for this test case)
+    return len(data) + 0
+
+def get_len_clone(data: Collection): pass  # pragma: no mutate
+
+
+# verify that mutmut can handle annotations that area 
+def get_foo_len(data: Foo) -> int:
+    return len(data.foo) + 0
+
+def get_foo_len_clone(data: Foo) -> int: pass  # pragma: no mutate
+
+@dataclass
+class Foo:
+    foo: list[str]

--- a/e2e_projects/py3_14_features/tests/test_py3_14_features.py
+++ b/e2e_projects/py3_14_features/tests/test_py3_14_features.py
@@ -1,0 +1,21 @@
+import annotationlib
+import inspect
+from py3_14_features import get_len, get_foo_len_clone, get_foo_len, get_len_clone, Foo
+
+def test_func_with_type_only_annotation():
+    assert get_len([1, 2, 3]) == 3
+
+def test_lazy_loaded_signature():
+    assert get_foo_len(Foo(["abc", "def"])) == 2
+
+def test_annotations():
+    # the get_len trampoline should have the correct annotations
+    assert annotationlib.get_annotations(get_len, format=annotationlib.Format.STRING) == {'data': 'Collection'}
+
+    # 'Foo' should be available at this point, so we do not need the STRING format
+    assert annotationlib.get_annotations(get_foo_len) == annotationlib.get_annotations(get_foo_len_clone)
+
+def test_signature():
+    # mutmut currently only achieves a stringified version, because we cannot eagerly evalute the signature
+    assert inspect.signature(get_len, annotation_format=inspect.Format.STRING) == inspect.signature(get_len_clone, annotation_format=inspect.Format.STRING)
+

--- a/e2e_projects/py3_14_features/uv.lock
+++ b/e2e_projects/py3_14_features/uv.lock
@@ -1,0 +1,69 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "24.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950, upload-time = "2024-11-08T09:47:47.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451, upload-time = "2024-11-08T09:47:44.722Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload-time = "2024-04-20T21:34:42.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload-time = "2024-04-20T21:34:40.434Z" },
+]
+
+[[package]]
+name = "py3-14-features"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.3.5" }]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
+]

--- a/tests/e2e/snapshots/my_lib.json
+++ b/tests/e2e/snapshots/my_lib.json
@@ -64,6 +64,12 @@
     "my_lib.x_escape_sequences__mutmut_5": 0,
     "my_lib.x_create_a_segfault_when_mutated__mutmut_1": -11,
     "my_lib.x_create_a_segfault_when_mutated__mutmut_2": 0,
-    "my_lib.x_create_a_segfault_when_mutated__mutmut_3": 0
+    "my_lib.x_create_a_segfault_when_mutated__mutmut_3": 0,
+    "my_lib.x_some_func__mutmut_1": 0,
+    "my_lib.x_some_func__mutmut_2": 0,
+    "my_lib.x_some_func__mutmut_3": 1,
+    "my_lib.x_func_with_star__mutmut_1": 1,
+    "my_lib.x_func_with_star__mutmut_2": 1,
+    "my_lib.x_func_with_arbitrary_args__mutmut_1": 1
   }
 }

--- a/tests/e2e/snapshots/py3_14_features.json
+++ b/tests/e2e/snapshots/py3_14_features.json
@@ -1,0 +1,8 @@
+{
+  "mutants/src/py3_14_features/__init__.py.meta": {
+    "py3_14_features.x_get_len__mutmut_1": 0,
+    "py3_14_features.x_get_len__mutmut_2": 1,
+    "py3_14_features.x_get_foo_len__mutmut_1": 0,
+    "py3_14_features.x_get_foo_len__mutmut_2": 1
+  }
+}

--- a/tests/e2e/test_e2e_result_snapshots.py
+++ b/tests/e2e/test_e2e_result_snapshots.py
@@ -4,6 +4,8 @@ import shutil
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
+import pytest
+import sys
 
 import mutmut
 from mutmut.__main__ import SourceFileMutationData, _run, ensure_config_loaded, walk_source_files
@@ -84,3 +86,9 @@ def test_config_result_snapshot():
 def test_mutate_only_covered_lines_result_snapshot():
     mutmut._reset_globals()
     asserts_results_did_not_change("mutate_only_covered_lines")
+
+
+@pytest.mark.skipif(sys.version_info < (3, 14), reason="Can only test python 3.14 features on 3.14")
+def test_python_3_14_result_snapshot():
+    mutmut._reset_globals()
+    asserts_results_did_not_change("py3_14_features")

--- a/tests/test_mutation.py
+++ b/tests/test_mutation.py
@@ -699,7 +699,7 @@ def foo(*args, **kwargs):
     result = _mutmut_trampoline(x_foo__mutmut_orig, x_foo__mutmut_mutants, args, kwargs)
     return result 
 
-foo.__signature__ = _mutmut_signature(x_foo__mutmut_orig)
+_mutmut_copy_signature(foo, x_foo__mutmut_orig)
 x_foo__mutmut_orig.__name__ = 'x_foo'
 
 def x_bar__mutmut_orig():
@@ -716,7 +716,7 @@ def bar(*args, **kwargs):
     result = _mutmut_trampoline(x_bar__mutmut_orig, x_bar__mutmut_mutants, args, kwargs)
     return result 
 
-bar.__signature__ = _mutmut_signature(x_bar__mutmut_orig)
+_mutmut_copy_signature(bar, x_bar__mutmut_orig)
 x_bar__mutmut_orig.__name__ = 'x_bar'
 
 class Adder:
@@ -733,7 +733,7 @@ class Adder:
         result = _mutmut_trampoline(object.__getattribute__(self, "xǁAdderǁ__init____mutmut_orig"), object.__getattribute__(self, "xǁAdderǁ__init____mutmut_mutants"), args, kwargs, self)
         return result 
     
-    __init__.__signature__ = _mutmut_signature(xǁAdderǁ__init____mutmut_orig)
+    _mutmut_copy_signature(__init__, xǁAdderǁ__init____mutmut_orig)
     xǁAdderǁ__init____mutmut_orig.__name__ = 'xǁAdderǁ__init__'
 
     def xǁAdderǁadd__mutmut_orig(self, value):
@@ -750,7 +750,7 @@ class Adder:
         result = _mutmut_trampoline(object.__getattribute__(self, "xǁAdderǁadd__mutmut_orig"), object.__getattribute__(self, "xǁAdderǁadd__mutmut_mutants"), args, kwargs, self)
         return result 
     
-    add.__signature__ = _mutmut_signature(xǁAdderǁadd__mutmut_orig)
+    _mutmut_copy_signature(add, xǁAdderǁadd__mutmut_orig)
     xǁAdderǁadd__mutmut_orig.__name__ = 'xǁAdderǁadd'
 
 print(Adder(1).add(2))"""

--- a/tests/test_mutmut3.py
+++ b/tests/test_mutmut3.py
@@ -37,7 +37,7 @@ def foo(*args, **kwargs):
     result = _mutmut_trampoline(x_foo__mutmut_orig, x_foo__mutmut_mutants, args, kwargs)
     return result 
 
-foo.__signature__ = _mutmut_signature(x_foo__mutmut_orig)
+_mutmut_copy_signature(foo, x_foo__mutmut_orig)
 x_foo__mutmut_orig.__name__ = 'x_foo'
 """
 
@@ -66,7 +66,7 @@ def foo(*args, **kwargs):
     result = _mutmut_trampoline(x_foo__mutmut_orig, x_foo__mutmut_mutants, args, kwargs)
     return result 
 
-foo.__signature__ = _mutmut_signature(x_foo__mutmut_orig)
+_mutmut_copy_signature(foo, x_foo__mutmut_orig)
 x_foo__mutmut_orig.__name__ = 'x_foo'
 """
 


### PR DESCRIPTION
Closes #463 

Python 3.14 supports deferred annotation loading. However, the `inspect.signature` raises an Error when trying to compute non-existing lazy-loaded annotations (which happens with `if TYPE_CHECKING` imports)

Instead of:

```python3
{orig_name}.__signature__ = _mutmut_signature({mangled_name}__mutmut_orig)
```

we now do:

```python3
_mutmut_copy_signature({orig_name}, {mangled_name}__mutmut_orig)

# ...

def _mutmut_copy_signature(trampoline, original_method):
    if _mutmut_sys.version_info >= (3, 14):
        # PEP 649 introduced deferred loading for annotations
        # When some_method.__annotations__ is accessed, Python uses some_method.__annotate__(format) to compute it
        # By copying the original __annotate__ method, we provide get the original annotations
        trampoline.__annotate__ = original_method.__annotate__
    else:
        # On Python 3.13 and earlier, __annotations__ can be accessed immediately
        trampoline.__annotations__ = original_method.__annotations__

    try:
        trampoline.__signature__ = _mutmut_inspect.signature(original_method)
    except NameError:
        # Also, because of PEP 649, it can happen that we cannot eagerly evaluate the signature
        # In this case, fall back to stringifying the signature (which could cause different behaviour with runtime introspection)
        trampoline.__signature__ = _mutmut_inspect.signature(original_method, annotation_format=_mutmut_inspect.Format.STRING)
```

I think this works in following cases:
- [x] Python 3.13 `inspect.get_annotations`
- [x] Python 3.13 `inspect.signature`
- [x] Python 3.14 `inspect.get_annotations`
- [x] Python 3.14 `inspect.signature` for eagerly available signatures
- [ ] Python 3.14 `inspect.signature` with deferred annotations (when mutmut cannot eagerly compute `signature(...)` it now stringifies the signature, which could break some introspection)

According to the docs, `get_annotations` is the best practice to read annotations, so I think it's okay that we're not fully supporting the `inspect.signature` for deferred annotations case. I've created #465 for future improvements.