### PR TITLE
Only mutate files if the source file has been modified

### DIFF
--- a/tests/test_generation_error_handling.py
+++ b/tests/test_generation_error_handling.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 
 import pytest
@@ -18,6 +19,8 @@ class MockConfig:
 def test_mutant_generation_raises_exception_on_invalid_syntax(monkeypatch):
     mutmut._reset_globals()
     mutmut.config = MockConfig()
+
+    shutil.rmtree('mutants', ignore_errors=True)
 
     source_files = [
         source_dir / "valid_syntax_1.py",


### PR DESCRIPTION
When running `mutmut run` a second time, it will now only mutate modified source files. It will run all mutants nonetheless, because a change in some source file A can influence if a mutant of source file B would survive.

This is done by comparing the modified times of the source file with the mutated file. If `source_mstat < mutant_mstat`, we know that the source file has not been modified after we saved the mutated file.

```bash
(traces-parser) oaie:~/coding/python/traces_parser$ rm -r mutants/
(traces-parser) oaie:~/coding/python/traces_parser$ mutmut run
⠹ Generating mutants
    done in 1244ms (40 files mutated, 0 ignored, 0 unmodified)
⠙ Running stats     
    done
⠦ Running clean tests
    done
⠸ Running forced fail test
    done
Running mutation testing
⠦ 1092/1092  🎉 797 🫥 165  ⏰ 0  🤔 0  🙁 130    00
41.34 mutations/second

(traces-parser) oaie:~/coding/python/traces_parser$ mutmut run
⠦ Generating mutants
    done in 86ms (0 files mutated, 0 ignored, 40 unmodified)
⠋ Listing all tests 
⠴ Running clean tests
    done
⠹ Running forced fail test
    done
Running mutation testing
⠴ 1092/1092  🎉 797 🫥 165  ⏰ 0  🤔 0  🙁 130    00
42.66 mutations/second

(traces-parser) oaie:~/coding/python/traces_parser$ touch traces_parser/datatypes/hexstring.py 
(traces-parser) oaie:~/coding/python/traces_parser$ mutmut run
⠦ Generating mutants
    done in 212ms (1 files mutated, 0 ignored, 39 unmodified)
⠋ Listing all tests 
⠴ Running clean tests
    done
⠹ Running forced fail test
    done
Running mutation testing
⠴ 1092/1092  🎉 797 🫥 165  ⏰ 0  🤔 0  🙁 130    00
41.84 mutations/second
```