### PR TITLE
fix: guard against empty mutants table in ResultBrowser (browse command)

### DIFF
--- a/src/mutmut/__main__.py
+++ b/src/mutmut/__main__.py
@@ -1777,7 +1777,7 @@ def browse(show_killed: bool) -> None:
         def get_mutant_name_from_selection(self) -> str | None:
             # noinspection PyTypeChecker
             mutants_table: DataTable[Any] = self.query_one("#mutants")  # type: ignore[assignment]
-            if mutants_table.cursor_row is None:
+            if mutants_table.cursor_row is None or not mutants_table.is_valid_row_index(mutants_table.cursor_row):
                 return
 
             return str(mutants_table.get_row_at(mutants_table.cursor_row)[0])
@@ -1801,7 +1801,7 @@ def browse(show_killed: bool) -> None:
             ensure_config_loaded()
             # noinspection PyTypeChecker
             mutants_table: DataTable[Any] = self.query_one("#mutants")  # type: ignore[assignment]
-            if mutants_table.cursor_row is None:
+            if mutants_table.cursor_row is None or not mutants_table.is_valid_row_index(mutants_table.cursor_row):
                 return
             apply_mutant(mutants_table.get_row_at(mutants_table.cursor_row)[0])
 


### PR DESCRIPTION
## Problem

Running `mutmut browse` crashes with `RowDoesNotExist: Row index 0 is not valid.` when pressing `t` (view tests) or triggering other mutant actions before a file with mutants is selected.

The root cause: `DataTable.cursor_row` returns `0` even when the table is empty, so the existing `cursor_row is None` guard does not protect against calling `get_row_at(0)` on an empty table.

## Fix

Use `is_valid_row_index()` (provided by Textual's `DataTable`) in addition to the `None` check in both `get_mutant_name_from_selection` and `action_apply_mutant`.