### PR TITLE
Follow up commits

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -174,9 +174,10 @@ For instance, mutmut mutates `x: str = 'foo'` to `x: str = None` which can easil
 
 Using this filter can improve performance and reduce noise, however it can also hide a few relevant mutations:
 
-1. `x: str = None` may not be valid, but if your tests do not detect such a change it indicates that
+1. We currently cannot mutate enums, staticmethods and classmethods in a type safe way. These won't be mutated.
+2. `x: str = None` may not be valid, but if your tests do not detect such a change it indicates that
     the value of `x` is not properly tested (even if your type checker would catch this particular modification)
-2. In some edge cases with class properties (usually in the `__init__` method), the way `mypy` and `pyrefly` infer types does not work well
+3. In some edge cases with class properties (usually in the `__init__` method), the way `mypy` and `pyrefly` infer types does not work well
     with the way mutmut mutates code. Some valid mutations like changing `self.x = 123` to `self.x = None` can
     be filtered out, even though the may be valid.
 

--- a/e2e_projects/type_checking/src/type_checking/__init__.py
+++ b/e2e_projects/type_checking/src/type_checking/__init__.py
@@ -1,3 +1,6 @@
+from enum import Enum
+from typing_extensions import Self
+
 def hello() -> str:
     greeting: str = "Hello from type-checking!"
     return greeting
@@ -14,6 +17,42 @@ class Person:
     def get_name(self):
         # return type should be inferred as "str"
         return self.name
+
+
+class Color(Enum):
+    RED = "red"
+    GREEN = "green"
+    BLUE = "blue"
+
+    def is_primary(self) -> bool:
+        return self in (Color.RED, Color.GREEN, Color.BLUE)
+
+    def darken(self) -> Self:
+        return Color.from_index(Color.to_index(self) + 1)
+
+    @staticmethod
+    def get_next_color(color: 'Color') -> 'Color':
+        return Color.from_index(Color.to_index(color) + 1 % 3)
+
+    @staticmethod
+    def to_index(color: 'Color'):
+        match color:
+            case Color.RED:
+                return 0
+            case Color.GREEN:
+                return 1
+            case Color.BLUE:
+                return 2
+
+    @staticmethod
+    def from_index(index: int) -> 'Color':
+        return [Color.RED, Color.GREEN, Color.BLUE][index + 0]
+
+    @classmethod
+    def create(cls, name: str) -> Self:
+        return cls(name)
+
+
 
 def mutate_me():
     p = Person()

--- a/e2e_projects/type_checking/tests/test_type_checking.py
+++ b/e2e_projects/type_checking/tests/test_type_checking.py
@@ -8,3 +8,18 @@ def test_a_hello_wrapper():
 
 def test_mutate_me():
     assert mutate_me() == "charlie"
+
+def test_color_from_index():
+    assert isinstance(Color.from_index(1), Color)
+
+def test_color_to_index():
+    assert isinstance(Color.to_index(Color.GREEN), int)
+
+def test_next_color_value():
+    assert Color.get_next_color(Color.RED) != Color.RED
+
+def test_create_color():
+    assert Color.create('red') == Color.RED
+
+def test_color_to_string():
+    assert Color.RED.darken() != Color.RED

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ source-include = ["HISTORY.rst"]
 dev = [
     "inline-snapshot>=0.32.0",
     "pre-commit>=4.5.1",
-    "pyrefly>=0.53.0",
+    "pyrefly>=0.59.1",
     "pytest-asyncio>=1.0.0",
     "ruff>=0.15.1",
 ]

--- a/src/mutmut/mutation/file_mutation.py
+++ b/src/mutmut/mutation/file_mutation.py
@@ -294,14 +294,16 @@ def combine_mutations_to_source(
                 # we don't mutate single-line classes, e.g. `class A: a = 1; b = 2`
                 result.append(cls)
             elif is_enum_class(cls):
-                external_nodes, modified_cls, enum_mutant_names = enum_trampoline_arrangement(
+                trampoline_nodes, external_nodes, modified_cls, enum_mutant_names = enum_trampoline_arrangement(
                     cls, mutations_within_function
                 )
-                result.extend(external_nodes)
+                result.extend(trampoline_nodes)
                 result.append(modified_cls)
+                result.extend(external_nodes)
                 mutation_names.extend(enum_mutant_names)
             else:
-                external_nodes_for_class: list[MODULE_STATEMENT] = []
+                pre_class_nodes: list[MODULE_STATEMENT] = []
+                post_class_nodes: list[MODULE_STATEMENT] = []
                 mutated_body = []
                 for method in cls.body.body:
                     method_mutants = mutations_within_function.get(method)
@@ -311,10 +313,11 @@ def combine_mutations_to_source(
 
                     method_type = get_method_type(method)
                     if method_type in (MethodType.STATICMETHOD, MethodType.CLASSMETHOD):
-                        ext_nodes, assignment, method_mutant_names = _external_method_injection(
+                        trampoline_nodes, ext_nodes, assignment, method_mutant_names = _external_method_injection(
                             method, method_mutants, cls.name.value, method_type
                         )
-                        external_nodes_for_class.extend(ext_nodes)
+                        pre_class_nodes.extend(trampoline_nodes)
+                        post_class_nodes.extend(ext_nodes)
                         mutated_body.append(assignment)
                         mutation_names.extend(method_mutant_names)
                     else:
@@ -324,8 +327,9 @@ def combine_mutations_to_source(
                         mutated_body.extend(nodes)
                         mutation_names.extend(mutant_names)
 
-                result.extend(external_nodes_for_class)
+                result.extend(pre_class_nodes)
                 result.append(cls.with_changes(body=cls.body.with_changes(body=mutated_body)))
+                result.extend(post_class_nodes)
         else:
             result.append(statement)
 
@@ -335,7 +339,7 @@ def combine_mutations_to_source(
 
 def _external_method_injection(
     method: cst.FunctionDef, mutants: Sequence[Mutation], class_name: str, method_type: MethodType
-) -> tuple[Sequence[MODULE_STATEMENT], cst.SimpleStatementLine, Sequence[str]]:
+) -> tuple[Sequence[MODULE_STATEMENT], Sequence[MODULE_STATEMENT], cst.SimpleStatementLine, Sequence[str]]:
     """Create external trampoline for a method using external injection pattern.
 
     This moves mutation code outside the class and uses a simple assignment
@@ -345,17 +349,14 @@ def _external_method_injection(
     :param mutants: The mutations for this method.
     :param class_name: The containing class name.
     :param method_type: MethodType.STATICMETHOD, MethodType.CLASSMETHOD, or MethodType.INSTANCE.
-    :return: A tuple of (external_nodes, class_body_assignment, mutant_names)."""
+    :return: A tuple of (trampoline_method_nodes, external_nodes, class_body_assignment, mutant_names)."""
     external_nodes: list[MODULE_STATEMENT] = []
     mutant_names: list[str] = []
     method_name = method.name.value
     prefix = f"_{class_name}_{method_name}"
     mangled_name = mangle_function_name(name=method_name, class_name=class_name) + "__mutmut"
 
-    stringify = StringifyAnnotations()
-
     orig_func = method.with_changes(name=cst.Name(f"{prefix}_orig"), decorators=[])
-    orig_func = cast(cst.FunctionDef, orig_func.visit(stringify))
     external_nodes.append(orig_func)
 
     for i, mutant in enumerate(mutants):
@@ -365,13 +366,13 @@ def _external_method_injection(
 
         mutated = method.with_changes(name=cst.Name(mutant_func_name), decorators=[])
         mutated = cast(cst.FunctionDef, deep_replace(mutated, mutant.original_node, mutant.mutated_node))
-        mutated = cast(cst.FunctionDef, mutated.visit(stringify))
         external_nodes.append(mutated)
-    trampoline_code = build_enum_trampoline(
+    trampoline_code, mutants_dict_code = build_enum_trampoline(
         class_name=class_name, method_name=method_name, mutant_names=mutant_names, method_type=method_type
     )
     trampoline_nodes = list(cst.parse_module(trampoline_code).body)
-    external_nodes.extend(trampoline_nodes)
+    mutants_dict_nodes = list(cst.parse_module(mutants_dict_code).body)
+    external_nodes.extend(mutants_dict_nodes)
 
     if method_type == MethodType.STATICMETHOD:
         assignment_code = f"{method_name} = staticmethod({prefix}_trampoline)"
@@ -382,7 +383,7 @@ def _external_method_injection(
 
     assignment = cast(cst.SimpleStatementLine, cst.parse_statement(assignment_code))
 
-    return external_nodes, assignment, mutant_names
+    return trampoline_nodes, external_nodes, assignment, mutant_names
 
 
 def function_trampoline_arrangement(
@@ -412,7 +413,7 @@ def function_trampoline_arrangement(
         mutated_method = cast(cst.FunctionDef, deep_replace(mutated_method, mutant.original_node, mutant.mutated_node))
         nodes.append(mutated_method)
 
-    # trampoline that forwards the calls
+    # mapping of mutant to the mutated method
     mutants_dict_code = build_mutants_dict_and_name(
         orig_name=name,
         class_name=class_name,
@@ -499,7 +500,7 @@ def create_trampoline_wrapper(function: cst.FunctionDef, mangled_name: str, clas
 
 def enum_trampoline_arrangement(
     cls: cst.ClassDef, mutations_by_method: Mapping[cst.CSTNode, Sequence[Mutation]]
-) -> tuple[Sequence[MODULE_STATEMENT], cst.ClassDef, Sequence[str]]:
+) -> tuple[Sequence[MODULE_STATEMENT], Sequence[MODULE_STATEMENT], cst.ClassDef, Sequence[str]]:
     """Create external functions and minimal enum class for enum mutation.
 
     This pattern moves all mutation-related code OUTSIDE the enum class body,
@@ -508,7 +509,8 @@ def enum_trampoline_arrangement(
 
     :param cls: The enum class definition.
     :param mutations_by_method: Mapping of method nodes to their mutations.
-    :return: A tuple of (external_nodes, modified_class, mutant_names)."""
+    :return: A tuple of (trampoline_nodes, external_nodes, modified_class, mutant_names)."""
+    trampoline_nodes: list[MODULE_STATEMENT] = []
     external_nodes: list[MODULE_STATEMENT] = []
     mutant_names: list[str] = []
     new_body: list[cst.BaseStatement | cst.BaseSmallStatement] = []
@@ -531,16 +533,17 @@ def enum_trampoline_arrangement(
             new_body.append(method)
             continue
 
-        ext_nodes, assignment, method_mutant_names = _external_method_injection(
+        tramp_nodes, ext_nodes, assignment, method_mutant_names = _external_method_injection(
             method, method_mutants, class_name, method_type
         )
+        trampoline_nodes.extend(tramp_nodes)
         external_nodes.extend(ext_nodes)
         new_body.append(assignment)
         mutant_names.extend(method_mutant_names)
 
     modified_cls = cls.with_changes(body=cls.body.with_changes(body=new_body))
 
-    return external_nodes, modified_cls, mutant_names
+    return trampoline_nodes, external_nodes, modified_cls, mutant_names
 
 
 def get_statements_until_func_or_class(statements: Sequence[MODULE_STATEMENT]) -> list[MODULE_STATEMENT]:
@@ -596,41 +599,6 @@ class ChildReplacementTransformer(cst.CSTTransformer):
             self.replaced_node = True
             return self.new_node
         return updated_node
-
-
-class StringifyAnnotations(cst.CSTTransformer):
-    """Convert type annotations to string literals to avoid NameError from forward references.
-
-    When methods are extracted from a class body and placed before the class definition,
-    annotations referencing the class (e.g., -> AsyncGenerator[Clazz, None]) would fail.
-    This transformer turns them into string literals (e.g., -> "AsyncGenerator[Clazz, None]").
-
-    This allows for mutations to be placed anywhere in the file, improving the resilience of
-    the mutation process without breaking type checking."""
-
-    _empty_module = cst.parse_module("")
-
-    def leave_Annotation(self, original_node: cst.Annotation, updated_node: cst.Annotation) -> cst.Annotation:
-        if isinstance(updated_node.annotation, (cst.SimpleString, cst.ConcatenatedString, cst.FormattedString)):
-            return updated_node
-        source = self._empty_module.code_for_node(updated_node.annotation)
-        return updated_node.with_changes(annotation=cst.SimpleString(self._format_source(source)))
-
-    def _format_source(self, source: str):
-        """Format the source annotation accounting for types with quotes inside the outer annotation
-
-        EX: List[ "NewClass" ] -> "List[ \"NewClass\" ]"
-
-        Attempts to default to more readable approaches but falls-safe to a globally
-        compatible approach regardless of quote style (including the seldom-used in this context triple quote).
-        """
-        if '"' not in source:
-            return f'"{source}"'
-        elif "'" not in source:
-            return f"'{source}'"
-        else:
-            escaped = source.replace('"', '\\"')
-            return f'"{escaped}"'
 
 
 def _is_generator(function: cst.FunctionDef) -> bool:

--- a/src/mutmut/mutation/file_mutation.py
+++ b/src/mutmut/mutation/file_mutation.py
@@ -223,6 +223,14 @@ class MutationVisitor(cst.CSTVisitor):
         ):
             return True
 
+        if Config.get().type_check_command:
+            if isinstance(node, cst.ClassDef) and is_enum_class(node):
+                # Currently, mutating enums breaks typing see type_checking E2E test for some examples
+                return True
+            if isinstance(node, cst.FunctionDef) and node.decorators:
+                # Currently, mutating staticmethod and classmethod breaks typing see type_checking E2E test for some examples
+                return True
+
         # ignore decorated functions, because
         # 1) copying them for the trampoline setup can cause side effects (e.g. multiple @app.post("/foo") definitions)
         # 2) decorators are executed when the function is defined, so we don't want to mutate their arguments and cause exceptions

--- a/src/mutmut/mutation/trampoline_templates.py
+++ b/src/mutmut/mutation/trampoline_templates.py
@@ -54,7 +54,7 @@ def build_mutants_dict_and_name(
 
 def build_enum_trampoline(
     *, class_name: str, method_name: str, mutant_names: list[str], method_type: MethodType
-) -> str:
+) -> tuple[str, str]:
     """Generate external trampoline code for enum methods.
 
     This pattern moves all mutation-related code OUTSIDE the enum class body,
@@ -65,7 +65,7 @@ def build_enum_trampoline(
     :param method_name: The method being mutated
     :param mutant_names: List of mutant function names (mangled)
     :param method_type: 'instance', 'static', or 'classmethod'
-    :return: String containing the external functions and mutants dict
+    :return: (trampoline code, mutants dict and orign name fix code)
     """
     prefix = f"_{class_name}_{method_name}"
     mangled_name = mangle_function_name(name=method_name, class_name=class_name)
@@ -102,7 +102,7 @@ def {prefix}_trampoline(self, *args, **kwargs):
 {prefix}_trampoline.__name__ = '{method_name}'
 """
 
-    return _mark_generated(f"\n\n{orig_name_fix}\n\n{mutants_dict}\n\n{trampoline}")
+    return _mark_generated(f"\n\n{trampoline}"), _mark_generated(f"\n\n{orig_name_fix}\n\n{mutants_dict}")
 
 
 # noinspection PyUnresolvedReferences

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from mutmut import Config
+
+
+@pytest.fixture(autouse=True)
+def reset_config():
+    Config.reset()

--- a/tests/mutation/test_mutation_runtime.py
+++ b/tests/mutation/test_mutation_runtime.py
@@ -62,7 +62,7 @@ class Color(Enum):
     GREEN = 2
     BLUE = 3
 
-    def describe(self) -> Literal[ "red" | 'green' | \"""blue\""" ]: # worst case type annotation
+    def describe(self) -> Literal[ "red", 'green', \"""blue\""" ]: # worst case type annotation
         return self.name.lower()
 
     @classmethod

--- a/tests/mutation/test_pragma_handling.py
+++ b/tests/mutation/test_pragma_handling.py
@@ -157,6 +157,16 @@ def bar():
         no_mutate, _ = parse_pragmas("test.py", source)
         assert no_mutate == {3, 4, 5}
 
+    def test_does_not_affect_code_before_comment(self):
+        source = """
+def foo():
+    x = 1
+    # pragma: no mutate block
+    y = 2
+"""
+        no_mutate, _ = parse_pragmas("test.py", source)
+        assert no_mutate == {4, 5}
+
     def test_includes_nested_indentation(self):
         source = """
 def foo():

--- a/uv.lock
+++ b/uv.lock
@@ -326,7 +326,7 @@ requires-dist = [
 dev = [
     { name = "inline-snapshot", specifier = ">=0.32.0" },
     { name = "pre-commit", specifier = ">=4.5.1" },
-    { name = "pyrefly", specifier = ">=0.53.0" },
+    { name = "pyrefly", specifier = ">=0.59.1" },
     { name = "pytest-asyncio", specifier = ">=1.0.0" },
     { name = "ruff", specifier = ">=0.15.1" },
 ]
@@ -394,18 +394,19 @@ wheels = [
 
 [[package]]
 name = "pyrefly"
-version = "0.53.0"
+version = "0.59.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/73/262196c4ea5afec6389366a4b3d49f67655c6396efa1a4053cca37be7c8d/pyrefly-0.53.0.tar.gz", hash = "sha256:aef117e8abb9aa4cf17fc64fbf450d825d3c65fc9de3c02ed20129ebdd57aa74", size = 5040338, upload-time = "2026-02-17T21:15:44.877Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/ce/7882c2af92b2ff6505fcd3430eff8048ece6c6254cc90bdc76ecee12dfab/pyrefly-0.59.1.tar.gz", hash = "sha256:bf1675b0c38d45df2c8f8618cbdfa261a1b92430d9d31eba16e0282b551e210f", size = 5475432, upload-time = "2026-04-01T22:04:04.11Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/9b/3af46ac06dcfd7b27f15e991d2d4f0082519e6906b1f304f511e4db3ad5f/pyrefly-0.53.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:79d7fb35dff0988b3943c26f74cc752fad54357a0bc33f7db665f02d1c9a5bcc", size = 12041081, upload-time = "2026-02-17T21:15:24.769Z" },
-    { url = "https://files.pythonhosted.org/packages/79/4f/23422479153f8f88d1699461bf8f22e32320bb0fc1272774ea8a17463302/pyrefly-0.53.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e1d98b1e86f3c38db44860695b7986e731238e1b19c3cad7a3050476a8f6f84d", size = 11604301, upload-time = "2026-02-17T21:15:27.23Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/9a/f4cc6b81a464c31c3112b46abbd44ccd569f01c71a0abf39eeccf6ace914/pyrefly-0.53.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb9f2440f7e0c70aa18400f44aed994c326a1ab00f2b01cf7253a63fc62d7c6b", size = 32674148, upload-time = "2026-02-17T21:15:29.762Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/cc/fa98606a628380b7ae4623dbc30843e8fed6b7a631c89503bdf123e47453/pyrefly-0.53.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e4e826a5ff2aba2c41e02e6094580751c512db7916e60728cd8612dbcf178d7b", size = 35099098, upload-time = "2026-02-17T21:15:32.383Z" },
-    { url = "https://files.pythonhosted.org/packages/71/d2/ab4105ee90495314a8ad6be4d6736c9f20e4b0ceb49cf015ddc84c394c25/pyrefly-0.53.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf4c69410c7a96b417a390a0e3d340f4370fdab02f9d3eaa222c4bd42e3ce24a", size = 37777824, upload-time = "2026-02-17T21:15:35.474Z" },
-    { url = "https://files.pythonhosted.org/packages/38/99/0779b7202d801cdf67f08159cf7dd318d23114661143689a767d9b8a98f1/pyrefly-0.53.0-py3-none-win32.whl", hash = "sha256:00687bb6be6e366b8c0137a89625da40ced3b9212a65e561857ff888fe88e6e8", size = 11111961, upload-time = "2026-02-17T21:15:38.455Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/71/dc7e59f0acb81dcf3f56e7ad30e740a08527403cb1d657caca9d44fef803/pyrefly-0.53.0-py3-none-win_amd64.whl", hash = "sha256:e0512e6f7af44ae01cfddba096ff7740e15cbd1d0497a3d34a7afcb504e2b300", size = 11888648, upload-time = "2026-02-17T21:15:40.471Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/72/2a7c00a439c6593430289a4581426efe0bee73f6e5a443f501969e104300/pyrefly-0.53.0-py3-none-win_arm64.whl", hash = "sha256:5066e2102769683749102421b8b8667cae26abe1827617f04e8df4317e0a94af", size = 11368150, upload-time = "2026-02-17T21:15:42.74Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/10/04a0e05b08fc855b6fe38c3df549925fc3c2c6e750506870de7335d3e1f7/pyrefly-0.59.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:390db3cd14aa7e0268e847b60cd9ee18b04273eddfa38cf341ed3bb43f3fef2a", size = 12868133, upload-time = "2026-04-01T22:03:39.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/78/fa7be227c3e3fcacee501c1562278dd026186ffd1b5b5beb51d3941a3aed/pyrefly-0.59.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d246d417b6187c1650d7f855f61c68fbfd6d6155dc846d4e4d273a3e6b5175cb", size = 12379325, upload-time = "2026-04-01T22:03:42.046Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/13/6828ce1c98171b5f8388f33c4b0b9ea2ab8c49abe0ef8d793c31e30a05cb/pyrefly-0.59.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:575ac67b04412dc651a7143d27e38a40fbdd3c831c714d5520d0e9d4c8631ab4", size = 35826408, upload-time = "2026-04-01T22:03:45.067Z" },
+    { url = "https://files.pythonhosted.org/packages/23/56/79ed8ece9a7ecad0113c394a06a084107db3ad8f1fefe19e7ded43c51245/pyrefly-0.59.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:062e6262ce1064d59dcad81ac0499bb7a3ad501e9bc8a677a50dc630ff0bf862", size = 38532699, upload-time = "2026-04-01T22:03:48.376Z" },
+    { url = "https://files.pythonhosted.org/packages/18/7d/ecc025e0f0e3f295b497f523cc19cefaa39e57abede8fc353d29445d174b/pyrefly-0.59.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:43ef4247f9e6f734feb93e1f2b75335b943629956e509f545cc9cdcccd76dd20", size = 36743570, upload-time = "2026-04-01T22:03:51.362Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/03/b1ce882ebcb87c673165c00451fbe4df17bf96ccfde18c75880dc87c5f5e/pyrefly-0.59.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59a2d01723b84d042f4fa6ec871ffd52d0a7e83b0ea791c2e0bb0ff750abce56", size = 41236246, upload-time = "2026-04-01T22:03:54.361Z" },
+    { url = "https://files.pythonhosted.org/packages/17/af/5e9c7afd510e7dd64a2204be0ed39e804089cbc4338675a28615c7176acb/pyrefly-0.59.1-py3-none-win32.whl", hash = "sha256:4ea70c780848f8376411e787643ae5d2d09da8a829362332b7b26d15ebcbaf56", size = 11884747, upload-time = "2026-04-01T22:03:56.776Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/c1/7db1077627453fd1068f0761f059a9512645c00c4c20acfb9f0c24ac02ec/pyrefly-0.59.1-py3-none-win_amd64.whl", hash = "sha256:67e6a08cfd129a0d2788d5e40a627f9860e0fe91a876238d93d5c63ff4af68ae", size = 12720608, upload-time = "2026-04-01T22:03:59.252Z" },
+    { url = "https://files.pythonhosted.org/packages/07/16/4bb6e5fce5a9cf0992932d9435d964c33e507aaaf96fdfbb1be493078a4a/pyrefly-0.59.1-py3-none-win_arm64.whl", hash = "sha256:01179cb215cf079e8223a064f61a074f7079aa97ea705cbbc68af3d6713afd15", size = 12223158, upload-time = "2026-04-01T22:04:01.869Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Follow up of #476 

Most importantly, do not mutate staticmethod, classmethod and enums when type_checking is enabled.

@nicklafleur In case you disagree with any of these changes, let me know and we can adapt in a future commit.