### PR TITLE
fix: diagnose silent test-to-mutant key mismatch in stats

### DIFF
--- a/src/mutmut/__main__.py
+++ b/src/mutmut/__main__.py
@@ -881,6 +881,54 @@ def collect_source_file_mutation_data(
     return mutants, source_file_mutation_data_by_path
 
 
+def _check_test_to_mutant_associations(
+    source_file_mutation_data_by_path: dict[str, SourceFileMutationData],
+) -> None:
+    """Detect when stats recorded trampoline hits but no recorded key matches any mutant key.
+
+    The trampoline records ``orig.__module__ + '.' + orig.__name__`` while the
+    per-mutant lookup uses the path-derived dotted name from ``get_mutant_name``.
+    In a healthy project these are equal because the test suite imports the
+    source via fully-qualified package paths and the source dir matches one of
+    the conventions handled by ``setup_source_paths``. When they diverge (e.g.
+    ``[tool.pytest.ini_options] pythonpath = ["pkg"]`` makes tests do
+    ``import foo`` instead of ``from pkg.foo import ...``) every mutant is
+    silently marked "No Tests" and the run reports 0.00 mutations/second.
+
+    This check exits with an actionable message instead of producing the silent
+    all-No-Tests outcome.
+    """
+    recorded = set(mutmut.tests_by_mangled_function_name.keys())
+    if not recorded:
+        # No hits at all - the existing zero-check in run_stats_collection
+        # already covers this path; nothing to add here.
+        return
+
+    expected = {
+        mangled_name_from_mutant_name(mutant_name)
+        for m in source_file_mutation_data_by_path.values()
+        for mutant_name in m.exit_code_by_key
+    }
+    if not expected or recorded & expected:
+        return
+
+    print(
+        "Stopping early, because tests recorded trampoline hits but none match any mutant key. "
+        "It looks like tests import the source under a different module path than mutmut sees from the file path."
+    )
+    print(f"Recorded keys (e.g.): {sorted(recorded)[:3]}")
+    print(f"Expected keys (e.g.): {sorted(expected)[:3]}")
+    print(
+        "Common causes: a pythonpath setting in pytest config, conftest sys.path injection, "
+        "or a source dir other than ./, src/, or source/."
+    )
+    print(
+        "Fix: use fully-qualified package imports (e.g. from pkg.foo import ...) "
+        "and rely on mutmut's default sys.path setup."
+    )
+    exit(1)
+
+
 def estimated_worst_case_time(mutant_name: str) -> float:
     tests = mutmut.tests_by_mangled_function_name.get(mangled_name_from_mutant_name(mutant_name), set())
     return sum(mutmut.duration_by_test[t] for t in tests)
@@ -898,6 +946,8 @@ def print_time_estimates(mutant_names: tuple[str, ...]) -> None:
     collect_or_load_stats(runner)
 
     mutants, source_file_mutation_data_by_path = collect_source_file_mutation_data(mutant_names=mutant_names)
+
+    _check_test_to_mutant_associations(source_file_mutation_data_by_path)
 
     times_and_keys = [(estimated_worst_case_time(mutant_name), mutant_name) for m, mutant_name, result in mutants]
 
@@ -986,6 +1036,8 @@ def _run(mutant_names: tuple[str, ...] | list[str], max_children: int | None) ->
     collect_or_load_stats(runner)
 
     mutants, source_file_mutation_data_by_path = collect_source_file_mutation_data(mutant_names=mutant_names)
+
+    _check_test_to_mutant_associations(source_file_mutation_data_by_path)
 
     os.environ["MUTANT_UNDER_TEST"] = ""
     with CatchOutput(spinner_title="Running clean tests") as output_catcher:

--- a/tests/test_check_associations.py
+++ b/tests/test_check_associations.py
@@ -1,0 +1,72 @@
+"""Tests for the test-to-mutant association sanity check."""
+
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+import mutmut
+from mutmut.__main__ import _check_test_to_mutant_associations
+from mutmut.mutation.data import SourceFileMutationData
+
+
+@pytest.fixture(autouse=True)
+def reset_tests_by_mangled_function_name():
+    saved = mutmut.tests_by_mangled_function_name
+    mutmut.tests_by_mangled_function_name = defaultdict(set)
+    yield
+    mutmut.tests_by_mangled_function_name = saved
+
+
+def _make_sfmd(mutant_names_per_path: dict[str, list[str]]) -> dict[str, SourceFileMutationData]:
+    """Build a fake source_file_mutation_data_by_path mapping."""
+    result: dict[str, SourceFileMutationData] = {}
+    for path_str, mutant_names in mutant_names_per_path.items():
+        m = SourceFileMutationData(path=Path(path_str))
+        m.exit_code_by_key = dict.fromkeys(mutant_names)
+        result[path_str] = m
+    return result
+
+
+class TestCheckTestToMutantAssociations:
+    def test_no_recorded_keys_is_noop(self):
+        # When stats recorded nothing, the existing zero-check elsewhere
+        # surfaces it. This function should not duplicate that work.
+        sfmd = _make_sfmd({"pkg/foo.py": ["pkg.foo.x_add__mutmut_1"]})
+        _check_test_to_mutant_associations(sfmd)  # must not exit
+
+    def test_overlapping_keys_is_noop(self):
+        # Healthy case: recorded key matches a mutant lookup key.
+        mutmut.tests_by_mangled_function_name["pkg.foo.x_add"].add("tests/test_foo.py::test_add")
+        sfmd = _make_sfmd({"pkg/foo.py": ["pkg.foo.x_add__mutmut_1"]})
+        _check_test_to_mutant_associations(sfmd)  # must not exit
+
+    def test_no_expected_keys_is_noop(self):
+        # No mutants generated yet -> nothing to compare against.
+        mutmut.tests_by_mangled_function_name["whatever.x_add"].add("tests/test_foo.py::test_add")
+        _check_test_to_mutant_associations({})  # must not exit
+
+    def test_disjoint_keys_exits_with_diagnostic(self, capsys):
+        # The bug case: trampolines were hit but recorded under a key shape
+        # (no path prefix) that no mutant lookup can ever match.
+        mutmut.tests_by_mangled_function_name["foo.x_add"].add("tests/test_foo.py::test_add")
+        mutmut.tests_by_mangled_function_name["foo.x_is_positive"].add("tests/test_foo.py::test_is_positive")
+        sfmd = _make_sfmd({"pkg/foo.py": ["pkg.foo.x_add__mutmut_1", "pkg.foo.x_is_positive__mutmut_1"]})
+
+        with pytest.raises(SystemExit) as exc_info:
+            _check_test_to_mutant_associations(sfmd)
+
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "tests recorded trampoline hits but none match any mutant key" in out
+        assert "pythonpath" in out
+        assert "Recorded keys" in out and "foo.x_add" in out
+        assert "Expected keys" in out and "pkg.foo.x_add" in out
+
+    def test_partial_overlap_is_noop(self):
+        # Even if only a subset matches, we don't bail - the per-mutant
+        # lookups for unmatched ones will simply yield "No Tests" which is
+        # legitimate (e.g. uncovered code).
+        mutmut.tests_by_mangled_function_name["pkg.foo.x_add"].add("tests/test_foo.py::test_add")
+        sfmd = _make_sfmd({"pkg/foo.py": ["pkg.foo.x_add__mutmut_1", "pkg.foo.x_uncovered__mutmut_1"]})
+        _check_test_to_mutant_associations(sfmd)  # must not exit


### PR DESCRIPTION
This adds a sanity check after stats collection that detects when tests recorded trampoline hits but none match any mutant lookup key. Without it, the run silently completes with every mutant marked "No Tests" and 0.00 mutations/second.

The trampoline records `orig.__module__ + '.' + orig.__name__` while per-mutant lookup uses the path-derived dotted name from `get_mutant_name`. They match in healthy projects (qualified package imports, source under `./`, `src/`, or `source/`). They diverge when tests use top-level imports enabled by pytest's `pythonpath` config, conftest `sys.path.insert`, or non-conventional source dirs. The existing zero-check in `run_stats_collection` doesn't catch the divergence because hits are recorded, just under unmatchable keys.

The new `_check_test_to_mutant_associations` runs after `collect_source_file_mutation_data` and exits early with sample recorded vs expected keys, in the same style as the existing "Stopping early" diagnostic.

Same symptom appears in #341, #351, #416, #419, all closed after users fixed their project setup. This change surfaces the cause earlier.

Fixes #515