### PR TITLE
Fix two prose errors in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ You can get started with a simple:
     pip install mutmut
     mutmut run
 
-This will by run pytest on tests in the "tests" or "test" folder and
+This will run pytest on tests in the "tests" or "test" folder and
 it will try to figure out where the code to mutate is.
 
 
@@ -511,7 +511,7 @@ This section describes how to work with mutmut to enhance your test suite.
 4. Press `r` to rerun the mutant and see if you successfully managed to kill it.
 
 Mutmut keeps the data of what it has done and the mutants in the `mutants/`
-directory.If  you want to make sure you run a full mutmut run you can delete
+directory. If you want to make sure you run a full mutmut run you can delete
 this directory to start from scratch.
 
 Contributing to Mutmut


### PR DESCRIPTION
## What

Fix two small prose errors in `README.rst`:

1. **Spurious word** — `"This will by run pytest"` → `"This will run pytest"` (the word `by` is an accidental leftover)
2. **Missing space + double space** — `"directory.If  you want"` → `"directory. If you want"` (period was run into the next sentence with two spaces instead of one)

## Why

Both make the sentence grammatically incorrect / hard to read for first-time users going through the quick-start.

## How verified

Inspected the rendered diff; no code changes, no tests affected.