### PR TITLE
Copy lockfile (uv.lock/poetry.lock/…) alongside pyproject.toml into the mutants tree

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,8 @@ Unreleased
 
 * Add `use_git_change_detection` config (default true) to opt out of git-based detection
 
+* Add `uv.lock`, `poetry.lock`, `Pipfile.lock`, and `pdm.lock` to the list of files copied by default
+
 * Invalidate cached results automatically when result-affecting config fields change
 
 

--- a/src/mutmut/configuration.py
+++ b/src/mutmut/configuration.py
@@ -132,6 +132,10 @@ def _load_config() -> Config:
             Path("test/"),
             Path("setup.cfg"),
             Path("pyproject.toml"),
+            Path("uv.lock"),
+            Path("poetry.lock"),
+            Path("Pipfile.lock"),
+            Path("pdm.lock"),
         ]
         + list(Path(".").glob("test*.py")),
         max_stack_depth=s("max_stack_depth", -1),

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -361,3 +361,7 @@ timeout_constant = 0.5
         assert Path("test/") in config.also_copy
         assert Path("setup.cfg") in config.also_copy
         assert Path("pyproject.toml") in config.also_copy
+        assert Path("uv.lock") in config.also_copy
+        assert Path("poetry.lock") in config.also_copy
+        assert Path("Pipfile.lock") in config.also_copy
+        assert Path("pdm.lock") in config.also_copy


### PR DESCRIPTION
## Link to Issue or Message thread
https://github.com/boxed/mutmut/issues/529


## Why is this change necessary?
Copying pyproject.toml but not the corresponding lockfile can cause mutmut to install different dependency versions during type checking than the project uses, which is hard for users to diagnose that that's what's happening.


## How does this change address the issue?
Adds `uv.lock`, `poetry.lock`, `Pipfile.lock`, and `pdm.lock` to the list of files copied by default.


## What side effects does this change have?
More files will be copied.


## How is this change tested?
Unit test expanded to assert those files are part of the default