### PR TITLE
chore(readme): fix typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ You can also write a mutant to disk from the `browse` interface, or via
 source code control and committed before you apply a mutant!
 
 
-If during the installation you get an error for the `libcst` dependency mentioning the lack of a rust compiler on your system, it is because your architecture does not have a prebuilt binary for `libcst` and it requires both `rustc` and `cargo` from the [rust toolchain](https://www.rust-lang.org/tools/install) to be built. This is known for at least the `x86_64-darwin` architecture.
+If during the installation you get an error for the `libcst` dependency mentioning the lack of a rust compiler on your system, it is because your architecture does not have a prebuilt binary for `libcst` and it requires both `rustc` and `cargo` from the `rust toolchain <https://www.rust-lang.org/tools/install>`_ to be built. This is known for at least the `x86_64-darwin` architecture.
 
 
 Wildcards for testing mutants


### PR DESCRIPTION
It uses MD link format in RST file but the «article» link above uses correct formatting style

https://github.com/boxed/mutmut/blob/main/README.rst?plain=1#L14