### PR TITLE
fix: mutate methods of decorated classes

### DIFF
--- a/src/mutmut/mutation/file_mutation.py
+++ b/src/mutmut/mutation/file_mutation.py
@@ -281,7 +281,12 @@ class MutationVisitor(cst.CSTVisitor):
                 if isinstance(decorator, cst.Name) and decorator.value in ("staticmethod", "classmethod"):
                     return False
             return True
-        if isinstance(node, cst.ClassDef) and len(node.decorators):
+
+        # decorators are executed at definition time, so mutating them can raise
+        # exceptions on import. A decorated class is still recursed into, because
+        # its decorator is kept on the original class and only its methods get
+        # trampolines, so reasons 1) and 3) above do not apply to it.
+        if isinstance(node, cst.Decorator):
             return True
 
         return False

--- a/tests/mutation/test_mutation.py
+++ b/tests/mutation/test_mutation.py
@@ -954,6 +954,24 @@ class A(Enum):
     assert not mutants
 
 
+@pytest.mark.parametrize("decorator", ["@dataclass", "@dataclass(frozen=True)"])
+def test_mutate_methods_of_decorated_classes(decorator):
+    # The decorator of a class is not copied into the trampoline, so
+    # decorating a class must not stop its methods from being mutated
+    source = f"""
+{decorator}
+class Foo:
+    x: int
+    y: int
+
+    def sum(self):
+        return self.x + self.y
+""".strip()
+
+    mutants = mutants_for_source(source)
+    assert mutants == [source.replace("self.x + self.y", "self.x - self.y")]
+
+
 def test_do_not_mutate_pattern_single_line(patch_config):
     source = 'logger.info("hello")'
     patch_config("do_not_mutate_patterns", [r"logger\.\w+\("])


### PR DESCRIPTION
Closes #480

`_skip_node_and_children` skipped any decorated `ClassDef` together with all its children, so every method of a `@dataclass` produced zero mutants. As you noted on the issue, the reasons for skipping decorated *functions* (trampoline copying side effects, `@property` signatures) don't apply to classes — a class decorator stays on the original class and only the methods get trampolines.

Rather than dropping the `ClassDef` check outright, the skip now applies to `cst.Decorator` itself. That keeps decorator arguments unmutated (otherwise `@dataclass(frozen=True)` mutates to `frozen=False`, which is executed at import time) while still recursing into the class body.
