### PR TITLE
feat: mutate ternary conditions

### DIFF
--- a/src/mutmut/mutation/mutators.py
+++ b/src/mutmut/mutation/mutators.py
@@ -248,6 +248,27 @@ def operator_match(node: cst.Match) -> Iterable[cst.CSTNode]:
             yield node.with_changes(cases=[*node.cases[:i], *node.cases[i + 1 :]])
 
 
+def operator_if_exp(node: cst.IfExp) -> Iterable[cst.IfExp]:
+    """Force a ternary down each branch by neutralising its condition.
+
+    A ternary's two arms are a branch that nothing else here mutates, and
+    branch coverage does not see an uncovered arm either, so an untested arm
+    reads as a pass twice over.
+
+    The condition is parenthesised before `and False` / `or True` is appended.
+    Without the parentheses `and` binds tighter than a top-level `or`, so
+    `b or c` would become `b or (c and False)` -- which still takes the true
+    branch whenever `b` is truthy, i.e. an almost-always-surviving mutant that
+    tests cannot kill. `or True` happens not to need them, but wrapping both
+    keeps one rule instead of two.
+    """
+    parenthesised = node.test.with_changes(lpar=[cst.LeftParen()], rpar=[cst.RightParen()])
+    for operator, literal in ((cst.And(), "False"), (cst.Or(), "True")):
+        yield node.with_changes(
+            test=cst.BooleanOperation(left=parenthesised, operator=operator, right=cst.Name(literal))
+        )
+
+
 # Operators that should be called on specific node types
 mutation_operators: OPERATORS_TYPE = [
     (cst.BaseNumber, operator_number),
@@ -265,6 +286,7 @@ mutation_operators: OPERATORS_TYPE = [
     (cst.CSTNode, operator_keywords),
     (cst.CSTNode, operator_swap_op),
     (cst.Match, operator_match),
+    (cst.IfExp, operator_if_exp),
 ]
 
 

--- a/tests/mutation/test_mutation.py
+++ b/tests/mutation/test_mutation.py
@@ -429,9 +429,13 @@ def test_function_with_annotation():
     print(mutated_code)
 
     expected_defs = [
-        "def x_capitalize__mutmut_1(s : str):\n    return s[0].title() - s[1:] if s else s",
-        "def x_capitalize__mutmut_2(s : str):\n    return s[1].title() + s[1:] if s else s",
-        "def x_capitalize__mutmut_3(s : str):\n    return s[0].title() + s[2:] if s else s",
+        # The ternary's condition is mutated first; `operator_if_exp` yields
+        # these two and shifts the arithmetic/index mutants down by two.
+        "def x_capitalize__mutmut_1(s : str):\n    return s[0].title() + s[1:] if (s) and False else s",
+        "def x_capitalize__mutmut_2(s : str):\n    return s[0].title() + s[1:] if (s) or True else s",
+        "def x_capitalize__mutmut_3(s : str):\n    return s[0].title() - s[1:] if s else s",
+        "def x_capitalize__mutmut_4(s : str):\n    return s[1].title() + s[1:] if s else s",
+        "def x_capitalize__mutmut_5(s : str):\n    return s[0].title() + s[2:] if s else s",
     ]
 
     for expected in expected_defs:


### PR DESCRIPTION
Closes #196. Credit to @ryanfreckleton for #478 — that is where I started, but the tree has moved (`node_mutation.py` is now `src/mutmut/mutation/mutators.py`), so this is a fresh implementation rather than a rebase.

## What was missing

A ternary is a branch nothing here mutated. Branch coverage does not see an uncovered arm either, so an untested arm read as a pass twice over. Before this, `grep -rn "IfExp\|ternary\|if_exp" src/ tests/ docs/` returned nothing.

`operator_if_exp` yields two mutants per ternary, forcing it down each arm:

```
a if b else c  ->  a if (b) and False else c
                   a if (b) or True else c
```

## The parentheses

The review on #478 asked to drop the precedence wrapping and use `node.test` directly. That is right for `or True` and wrong for `and False`, because `and` binds tighter than a top-level `or`. Over all 16 assignments of `a if b or c else d`:

| mutant | differs from original |
|---|---|
| `(b or c) and False` | **6 / 16** |
| `b or c and False` | 2 / 16, and only when `b` is falsy |
| `(b or c) or True` | 2 / 16 |
| `b or c or True` | 2 / 16 — identical to the wrapped form |

Unparenthesised, `b or c and False` parses as `b or (c and False)` and still takes the true branch whenever `b` is truthy, i.e. a mutant tests mostly cannot kill.

`or True` genuinely does not need the parentheses. I wrap both anyway so there is one rule instead of two, and it costs nothing — happy to make it asymmetric if you prefer.

## Test impact

`test_function_with_annotation` shifts because its fixture contains a ternary: the two new mutants take numbers 1 and 2 and push the arithmetic and index mutants to 3–5. The three original assertions are kept and renumbered, and the two new mutants are asserted alongside them, so the test still shows nothing was lost.

## Verification

`pytest tests/` on 4f12080:

| | failed | passed |
|---|---|---|
| before | 12 | 345 |
| after | 12 | 345 |

Identical `FAILED` sets — I diffed them. The e2e inline-snapshot suite is unchanged.

`tests/utils/test_safe_setproctitle.py` is flaky on this machine regardless of the change (1 pass in 5 runs both with and without it), so it moves in and out of that list on its own; I checked rather than attributing it.

`ruff check`, `ruff format --check` and `mypy` all pass on the two changed files.
