### PR TITLE
fix: support legitimate top-level src packages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,11 @@ If you use `pyproject.toml`, you must specify the paths as array in a `tool.mutm
     source_paths = [ "src/" ]
     pytest_add_cli_args_test_selection= [ "tests/" ]
 
+For a standard ``src`` layout, import the package inside ``src`` rather than
+importing ``src`` itself. If ``src/__init__.py`` exists because ``src`` is the
+actual top-level package, mutmut recognizes that package and preserves its
+``src.`` module prefix in mutant names.
+
 See below for more options for configuring mutmut.
 
 

--- a/e2e_projects/src_package/pyproject.toml
+++ b/e2e_projects/src_package/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.mutmut]
+source_paths = ["src/"]
+pytest_add_cli_args_test_selection = ["tests/"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/e2e_projects/src_package/src/__init__.py
+++ b/e2e_projects/src_package/src/__init__.py
@@ -1,0 +1,1 @@
+"""A legitimate top-level package named src."""

--- a/e2e_projects/src_package/src/calculator.py
+++ b/e2e_projects/src_package/src/calculator.py
@@ -1,0 +1,2 @@
+def add_one(value: int) -> int:
+    return value + 1

--- a/e2e_projects/src_package/tests/test_calculator.py
+++ b/e2e_projects/src_package/tests/test_calculator.py
@@ -1,0 +1,5 @@
+from src.calculator import add_one
+
+
+def test_add_one() -> None:
+    assert add_one(1) == 2

--- a/src/mutmut/__main__.py
+++ b/src/mutmut/__main__.py
@@ -122,13 +122,16 @@ exit_code_to_emoji = {exit_code: emoji_by_status[status] for exit_code, status i
 
 
 def record_trampoline_hit(name: str, caller: str | None = None) -> None:
-    assert not name.startswith("src."), "Failed trampoline hit. Module name starts with `src.`, which is invalid"
+    config = Config.get()
+    assert not name.startswith("src.") or config.src_package_exists, (
+        "Failed trampoline hit. Module name starts with `src.`, which is invalid unless src/__init__.py exists"
+    )
 
-    mutated_source_paths = Config.get().resolved_mutated_source_paths
+    mutated_source_paths = config.resolved_mutated_source_paths
 
-    if Config.get().max_stack_depth != -1:
+    if config.max_stack_depth != -1:
         f = inspect.currentframe()
-        c = Config.get().max_stack_depth
+        c = config.max_stack_depth
         while c and f:
             filename = f.f_code.co_filename
             f = f.f_back
@@ -143,7 +146,7 @@ def record_trampoline_hit(name: str, caller: str | None = None) -> None:
             return
 
     mutmut._stats.add(name)
-    if caller is not None and Config.get().track_dependencies:
+    if caller is not None and config.track_dependencies:
         state().function_dependencies[name].add(caller)
 
 
@@ -301,6 +304,7 @@ def copy_also_copy_files() -> None:
 
 def create_mutants_for_file(filename: Path, output_path: Path) -> FileMutationResult:
     warnings: list[Warning] = []
+    preserve_src_prefix = Config.get().src_package_exists
 
     try:
         source_mtime = os.path.getmtime(filename)
@@ -312,10 +316,23 @@ def create_mutants_for_file(filename: Path, output_path: Path) -> FileMutationRe
         if source_mtime < mutant_mtime:
             data = SourceFileMutationData(path=filename)
             data.load()
-            return FileMutationResult(
-                unmodified=True,
-                current_hashes={get_mutant_name(filename, func): h for func, h in data.hash_by_function_name.items()},
+            cached_names_are_current = not (
+                preserve_src_prefix
+                and filename.parts[0] == "src"
+                and any(not key.startswith("src.") for key in data.exit_code_by_key)
             )
+            if cached_names_are_current:
+                return FileMutationResult(
+                    unmodified=True,
+                    current_hashes={
+                        get_mutant_name(
+                            filename,
+                            func,
+                            preserve_src_prefix=preserve_src_prefix,
+                        ): h
+                        for func, h in data.hash_by_function_name.items()
+                    },
+                )
     except OSError:
         pass
 
@@ -351,7 +368,7 @@ def create_mutants_for_file(filename: Path, output_path: Path) -> FileMutationRe
 
     merged: dict[str, int | None] = {}
     for name in mutated_file.mutant_names:
-        key = get_mutant_name(filename, name)
+        key = get_mutant_name(filename, name, preserve_src_prefix=preserve_src_prefix)
         func = mangled_name_from_mutant_name(key).rpartition(".")[2]
         if func not in hash_by_function_name or func in changed:
             merged[key] = None
@@ -363,8 +380,13 @@ def create_mutants_for_file(filename: Path, output_path: Path) -> FileMutationRe
 
     MutantLineSpans(path=filename, span_by_function_name=mutated_file.line_span_by_function_name).save()
 
-    current_hashes_qualified = {get_mutant_name(filename, func): h for func, h in hash_by_function_name.items()}
-    changed_functions_qualified = {get_mutant_name(filename, func) for func in changed}
+    current_hashes_qualified = {
+        get_mutant_name(filename, func, preserve_src_prefix=preserve_src_prefix): h
+        for func, h in hash_by_function_name.items()
+    }
+    changed_functions_qualified = {
+        get_mutant_name(filename, func, preserve_src_prefix=preserve_src_prefix) for func in changed
+    }
 
     return FileMutationResult(
         warnings=warnings,
@@ -479,7 +501,7 @@ class PytestRunner(TestRunner):
 
             # noinspection PyMethodMayBeStatic
             def pytest_runtest_makereport(self, item: Any, call: Any) -> None:
-                if call.when != 'call':
+                if call.when != "call":
                     return
                 mutmut.duration_by_test[item.nodeid] += call.duration
 

--- a/src/mutmut/configuration.py
+++ b/src/mutmut/configuration.py
@@ -142,6 +142,7 @@ def _load_config() -> Config:
         debug=s("debug", False),
         mutate_only_covered_lines=s("mutate_only_covered_lines", False),
         source_paths=source_paths,
+        src_package_exists=(Path("src") / "__init__.py").is_file(),
         resolved_mutated_source_paths=resolved_mutated_source_paths,
         pytest_add_cli_args=s("pytest_add_cli_args", []),
         pytest_add_cli_args_test_selection=pytest_add_cli_args_test_selection,
@@ -186,6 +187,7 @@ class Config:
     cache_invalidation_exclude: list[str]
     on_dependency_change: str
     use_git_change_detection: bool
+    src_package_exists: bool = False
 
     def config_fingerprint(self) -> dict[str, str]:
         """Hash the config fields that can change cached mutant *results*, grouped so the

--- a/src/mutmut/mutation/file_mutation.py
+++ b/src/mutmut/mutation/file_mutation.py
@@ -655,7 +655,8 @@ def group_by_path(errors: list[TypeCheckingError]) -> dict[Path, list[TypeChecki
 
 def filter_mutants_with_type_checker() -> dict[str, FailedTypeCheckMutant]:
     with change_cwd(Path("mutants")):
-        errors = run_type_checker(Config.get().type_check_command)
+        config = Config.get()
+        errors = run_type_checker(config.type_check_command)
         errors_by_path = group_by_path(errors)
 
         mutants_to_skip: dict[str, FailedTypeCheckMutant] = {}
@@ -683,7 +684,11 @@ def filter_mutants_with_type_checker() -> dict[str, FailedTypeCheckMutant]:
                         "If your project normally has no type errors and uses mypy/pyrefly, please file an issue with steps to reproduce on github.\n"
                     )
 
-                mutant_name = get_mutant_name(path.relative_to(Path(".").absolute()), mutant.function_name)
+                mutant_name = get_mutant_name(
+                    path.relative_to(Path(".").absolute()),
+                    mutant.function_name,
+                    preserve_src_prefix=config.src_package_exists,
+                )
 
                 mutants_to_skip[mutant_name] = FailedTypeCheckMutant(
                     method_location=mutant,

--- a/src/mutmut/utils/format_utils.py
+++ b/src/mutmut/utils/format_utils.py
@@ -58,9 +58,15 @@ def get_module_from_key(key: str) -> str:
     return key.rsplit(".", 1)[0] if "." in key else key
 
 
-def get_mutant_name(relative_source_path: Path, mutant_method_name: str) -> str:
+def get_mutant_name(
+    relative_source_path: Path,
+    mutant_method_name: str,
+    *,
+    preserve_src_prefix: bool = False,
+) -> str:
     module_name = str(relative_source_path)[: -len(relative_source_path.suffix)].replace(os.sep, ".")
-    module_name = strip_prefix(module_name, prefix="src.")
+    if not preserve_src_prefix:
+        module_name = strip_prefix(module_name, prefix="src.")
 
     # FYI, we currently use "mutant_name" inconsistently, for both the whole identifier including the path and only the mangled method name
     mutant_name = f"{module_name}.{mutant_method_name}"

--- a/tests/e2e/test_e2e_src_package.py
+++ b/tests/e2e/test_e2e_src_package.py
@@ -1,0 +1,15 @@
+from inline_snapshot import snapshot
+
+from tests.e2e.e2e_utils import run_mutmut_on_project
+
+
+def test_src_package_result_snapshot():
+    assert run_mutmut_on_project("src_package") == snapshot(
+        {
+            "mutants/src/__init__.py.meta": {},
+            "mutants/src/calculator.py.meta": {
+                "src.calculator.x_add_one__mutmut_1": 1,
+                "src.calculator.x_add_one__mutmut_2": 1,
+            },
+        }
+    )

--- a/tests/mutation/test_mutation.py
+++ b/tests/mutation/test_mutation.py
@@ -1470,6 +1470,39 @@ def test_record_trampoline_hit_skips_caller_when_disabled(monkeypatch):
     reset_state()
 
 
+def test_record_trampoline_hit_rejects_src_layout_import(monkeypatch):
+    cfg = _config_for_invalidation(src_package_exists=False)
+    monkeypatch.setattr(Config, "get", lambda: cfg)
+
+    with pytest.raises(AssertionError, match="invalid unless src/__init__.py exists"):
+        record_trampoline_hit("src.calculator.x_add_one")
+
+
+def test_record_trampoline_hit_accepts_src_package(monkeypatch):
+    mutmut._stats.clear()
+    cfg = _config_for_invalidation(src_package_exists=True)
+    monkeypatch.setattr(Config, "get", lambda: cfg)
+
+    record_trampoline_hit("src.calculator.x_add_one")
+
+    assert "src.calculator.x_add_one" in mutmut._stats
+
+
+def test_get_mutant_name_preserves_real_src_package_prefix():
+    assert (
+        get_mutant_name(
+            Path("src/calculator.py"),
+            "x_add_one__mutmut_1",
+            preserve_src_prefix=True,
+        )
+        == "src.calculator.x_add_one__mutmut_1"
+    )
+
+
+def test_get_mutant_name_strips_src_layout_prefix_by_default():
+    assert get_mutant_name(Path("src/calculator.py"), "x_add_one__mutmut_1") == "calculator.x_add_one__mutmut_1"
+
+
 def test_cleanup_stale_stats_removes_unknown_modules(monkeypatch):
     """_cleanup_stale_stats removes test associations for modules not in current_function_hashes."""
 
@@ -1535,6 +1568,7 @@ def _config_for_invalidation(**overrides):
         max_stack_depth=-1,
         debug=False,
         source_paths=[pathlib.Path("src")],
+        src_package_exists=False,
         resolved_mutated_source_paths=[(pathlib.Path("mutants") / "src").absolute()],
         pytest_add_cli_args=[],
         pytest_add_cli_args_test_selection=[],

--- a/tests/mutation/test_mutation.py
+++ b/tests/mutation/test_mutation.py
@@ -24,6 +24,7 @@ from mutmut.__main__ import _report_watched_file_changes
 from mutmut.__main__ import _reset_mutant_results
 from mutmut.__main__ import apply_mutant
 from mutmut.__main__ import compute_watched_file_hashes
+from mutmut.__main__ import create_mutants_for_file
 from mutmut.__main__ import get_diff_for_mutant
 from mutmut.__main__ import git_changed_non_py_files
 from mutmut.__main__ import git_head
@@ -1501,6 +1502,39 @@ def test_get_mutant_name_preserves_real_src_package_prefix():
 
 def test_get_mutant_name_strips_src_layout_prefix_by_default():
     assert get_mutant_name(Path("src/calculator.py"), "x_add_one__mutmut_1") == "calculator.x_add_one__mutmut_1"
+
+
+def test_src_package_regenerates_cache_with_unqualified_names(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cfg = _config_for_invalidation(src_package_exists=True)
+    monkeypatch.setattr(Config, "get", lambda: cfg)
+
+    source_path = Path("src/calculator.py")
+    source_path.parent.mkdir()
+    source = "def add_one(value):\n    return value + 1\n"
+    source_path.write_text(source)
+
+    output_path = Path("mutants/src/calculator.py")
+    output_path.parent.mkdir(parents=True)
+    output_path.write_text(source)
+
+    mutated_file = mutate_file_contents(str(source_path), source)
+    data = SourceFileMutationData(path=source_path)
+    data.exit_code_by_key = {get_mutant_name(source_path, name): 1 for name in mutated_file.mutant_names}
+    data.hash_by_function_name = dict(mutated_file.hash_by_function_name)
+    data.save()
+
+    source_mtime = source_path.stat().st_mtime_ns
+    os.utime(output_path, ns=(source_mtime + 1_000_000, source_mtime + 1_000_000))
+
+    result = create_mutants_for_file(source_path, output_path)
+
+    migrated = SourceFileMutationData(path=source_path)
+    migrated.load()
+    assert result.unmodified is False
+    assert migrated.exit_code_by_key
+    assert all(key.startswith("src.calculator.") for key in migrated.exit_code_by_key)
+    assert set(migrated.exit_code_by_key.values()) == {None}
 
 
 def test_cleanup_stale_stats_removes_unknown_modules(monkeypatch):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -64,6 +64,7 @@ class TestShouldMutateFile:
             max_stack_depth=-1,
             debug=False,
             source_paths=[],
+            src_package_exists=False,
             resolved_mutated_source_paths=[],
             pytest_add_cli_args=[],
             pytest_add_cli_args_test_selection=[],
@@ -343,6 +344,7 @@ timeout_constant = 0.5
         assert config.debug is False
         assert config.max_stack_depth == -1
         assert config.source_paths == [Path("src")]
+        assert config.src_package_exists is False
         assert config.only_mutate == []
         assert config.do_not_mutate == []
         assert config.mutate_only_covered_lines is False
@@ -351,6 +353,15 @@ timeout_constant = 0.5
         assert config.type_check_command == []
         assert config.track_dependencies is True
         assert config.dependency_tracking_depth == -1
+
+    def test_detects_top_level_src_package(self, in_tmp_dir: Path):
+        src = in_tmp_dir / "src"
+        src.mkdir()
+        (src / "__init__.py").touch()
+
+        config = _load_config()
+
+        assert config.src_package_exists is True
 
     def test_also_copy_includes_defaults(self, in_tmp_dir: Path):
         (in_tmp_dir / "src").mkdir()


### PR DESCRIPTION
## Summary

- recognize `src/__init__.py` as evidence that `src` is the actual top-level package
- preserve `src.` consistently in trampoline hits, mutant keys, hashes, and type-checker filtering
- keep the existing guard and prefix stripping for conventional src-layout projects
- migrate stripped keys left by a failed pre-fix run without requiring manual cache deletion

This addresses the top-level `src` package failure described in #373 while preserving the safeguard discussed by the maintainer in that thread.

## Root cause and reproduction

A project with `src/__init__.py`, tests importing `src.calculator`, and `source_paths = ["src/"]` passes pytest but fails mutmut during stats collection:

```text
AssertionError: Failed trampoline hit. Module name starts with `src.`, which is invalid
```

The assertion and path-derived key normalization made conflicting assumptions: Python records `src.calculator...`, while mutmut always strips the `src.` prefix from the corresponding mutant key. Relaxing only the assertion would therefore leave stats and mutant keys mismatched.

## Behavior and compatibility

Mutmut now detects the package marker during configuration loading and preserves `src.` only for that case. Projects using a conventional src layout without `src/__init__.py` retain the existing fail-fast behavior and stripped keys.

For an affected project with a cache generated before this fix, mutmut detects legacy stripped keys, regenerates the file once, and then resumes the existing unmodified-file cache path. A direct regression test covers that migration.

The optional `preserve_src_prefix` argument is keyword-only and defaults to the established behavior. `Config.src_package_exists` also has a compatibility-preserving default. No dependency, lockfile, command-line, or serialized-format change is included.

## Verification

- new end-to-end fixture for an actual top-level package named `src`
- 7 focused guard, configuration, naming, cache-migration, and end-to-end tests passed on Python 3.10.20 and 3.14.6
- full local suite: 386 passed, 2 skipped
- all pre-commit hooks passed, including Ruff and mypy
- current consumer `saagpatel/GithubRepoAuditor@3c0e369`: 155 focused tests passed, and all four selected `src.scorer.x_letter_grade` mutants were killed with exit status 0
- baseline `boxed/mutmut@5cb006d` reproduces the consumer failure at `record_trampoline_hit`

## Scope and risk

The detection intentionally requires `src/__init__.py`; PEP 420 namespace packages named `src` remain out of scope. Conventional src layouts are unchanged. The patch adds one project-local `is_file()` check during configuration loading; only an affected legacy cache pays a one-time regeneration cost.

This draft does not address the separate runner or JUnit requests in #373.
