### PR TITLE
Fix mutants missed when tests clear os.environ

### DIFF
--- a/ARCHITECTURE.rst
+++ b/ARCHITECTURE.rst
@@ -13,7 +13,7 @@ This phase creates a ``./mutants/`` directory, which will be used by all followi
 
 We start by copying ``source_paths`` to ``mutants/`` and then mutate the ``*.py`` files in there. Finally, we also copy ``also_copy`` paths to ``mutants/``, including the (guessed) test directories and some project files.
 
-The mutated files contains the original code and the mutants. With the ``MUTANT_UNDER_TEST`` environment variable, we can specify (among other things) which mutant should be enabled. If a mutant is not enabled, it will run the original code.
+The mutated files contains the original code and the mutants. The active mutant is stored in process-local state (and mirrored to the ``MUTANT_UNDER_TEST`` environment variable). If a mutant is not enabled, it will run the original code.
 
 
 Collecting tests and stats

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ~~~~~~~~~~
 
+* Fix mutants being reported as survived when a test uses ``patch.dict(os.environ, ..., clear=True)`` (`#511`)
+
 * Fix `mutate_only_covered_lines` mutating code that coverage.py excludes from measurement (`# pragma: no cover`, `exclude_lines`, `exclude_also`). Such lines are reported as covered when they run, so they used to produce mutants that could only ever survive
 
 * Fix mutations that delete ignored code. Dropping a `case` from a `match`, or an argument from a call, is a mutation of the enclosing node, so it used to be made even when the removed lines were themselves ignored

--- a/src/mutmut/__main__.py
+++ b/src/mutmut/__main__.py
@@ -479,7 +479,7 @@ class PytestRunner(TestRunner):
 
             # noinspection PyMethodMayBeStatic
             def pytest_runtest_makereport(self, item: Any, call: Any) -> None:
-                if call.when != 'call':
+                if call.when != "call":
                     return
                 mutmut.duration_by_test[item.nodeid] += call.duration
 
@@ -677,8 +677,20 @@ def print_stats(
     )
 
 
+def _set_mutant_under_test(name: str) -> None:
+    """Activate a mutant in process-local state and the environment.
+
+    Late-import the trampoline setter: that module imports from this file
+    at load time. The process-local copy is used when tests scrub
+    ``os.environ``. See #511.
+    """
+    from mutmut.mutation.trampoline import set_mutant_under_test
+
+    set_mutant_under_test(name)
+
+
 def run_forced_fail_test(runner: TestRunner) -> None:
-    os.environ["MUTANT_UNDER_TEST"] = "fail"
+    _set_mutant_under_test("fail")
     with CatchOutput(spinner_title="Running forced fail test") as catcher:
         try:
             if runner.run_forced_fail() == 0:
@@ -687,7 +699,7 @@ def run_forced_fail_test(runner: TestRunner) -> None:
                 raise SystemExit(1)
         except MutmutProgrammaticFailException:
             pass
-    os.environ["MUTANT_UNDER_TEST"] = ""
+    _set_mutant_under_test("")
     print("    done")
 
 
@@ -759,7 +771,7 @@ def run_stats_collection(runner: TestRunner, tests: Iterable[str] | None = None)
     if tests is None:
         tests = []  # Meaning all...
 
-    os.environ["MUTANT_UNDER_TEST"] = "stats"
+    _set_mutant_under_test("stats")
     os.environ["PY_IGNORE_IMPORTMISMATCH"] = "1"
     depth = Config.get().dependency_tracking_depth
     os.environ["MUTMUT_DEPENDENCY_DEPTH"] = str(depth)
@@ -1120,7 +1132,7 @@ def collect_or_load_stats(
 
         # Run incremental stats
         with CatchOutput(spinner_title="Listing all tests") as output_catcher:
-            os.environ["MUTANT_UNDER_TEST"] = "list_all_tests"
+            _set_mutant_under_test("list_all_tests")
             try:
                 all_tests_result = runner.list_all_tests()
             except CollectTestsFailedException:
@@ -1419,7 +1431,7 @@ def run(mutant_names: tuple[str, ...] | list[str], *, max_children: int | None) 
 def _run(mutant_names: tuple[str, ...] | list[str], max_children: int | None) -> None:
     # TODO: run no-ops once in a while to detect if we get false negatives
     # TODO: we should be able to get information on which tests killed mutants, which means we can get a list of tests and how many mutants each test kills. Those that kill zero mutants are redundant!
-    os.environ["MUTANT_UNDER_TEST"] = "mutant_generation"
+    _set_mutant_under_test("mutant_generation")
     Config.ensure_loaded()
 
     if max_children is None:
@@ -1461,7 +1473,7 @@ def _run(mutant_names: tuple[str, ...] | list[str], max_children: int | None) ->
 
     _check_test_to_mutant_associations(source_file_mutation_data_by_path)
 
-    os.environ["MUTANT_UNDER_TEST"] = ""
+    _set_mutant_under_test("")
     with CatchOutput(spinner_title="Running clean tests") as output_catcher:
         tests = tests_for_mutant_names(mutant_names)
 
@@ -1523,7 +1535,7 @@ def _run(mutant_names: tuple[str, ...] | list[str], max_children: int | None) ->
             pid = os.fork()
             if pid == 0:
                 # In the child
-                os.environ["MUTANT_UNDER_TEST"] = mutant_name
+                _set_mutant_under_test(mutant_name)
                 setproctitle(f"mutmut: {mutant_name}")
 
                 # Run fast tests first

--- a/src/mutmut/mutation/trampoline.py
+++ b/src/mutmut/mutation/trampoline.py
@@ -26,13 +26,45 @@ R = TypeVar("R")
 F = TypeVar("F", bound=Callable[..., Any])
 
 
+# Process-local copy of the active mutant. Tests that scrub os.environ
+# (``patch.dict(..., clear=True)``) must not be able to disable it. See #511.
+_mutant_under_test: str | None = None
+
+
+def set_mutant_under_test(name: str | None) -> None:
+    """Record the active mutant in process-local state.
+
+    ``None`` clears the override so the trampoline falls back to ``os.environ``.
+    A string value is also mirrored into ``MUTANT_UNDER_TEST`` for compatibility.
+    """
+    global _mutant_under_test
+    _mutant_under_test = name
+    if name is not None:
+        os.environ["MUTANT_UNDER_TEST"] = name
+
+
+def get_mutant_under_test() -> str:
+    """Return the active mutant name.
+
+    If ``MUTANT_UNDER_TEST`` is in the environment, that value wins so
+    existing tests and callers that only set the env var keep working.
+    If the key is missing (for example after ``patch.dict(..., clear=True)``),
+    fall back to the process-local copy set by ``set_mutant_under_test``.
+    """
+    if "MUTANT_UNDER_TEST" in os.environ:
+        return os.environ["MUTANT_UNDER_TEST"]
+    if _mutant_under_test is not None:
+        return _mutant_under_test
+    return ""
+
+
 def wrap_in_trampoline(
     mutants_dict: dict[str, F], is_classmethod: bool = False
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     def mutmut_mutated(decorated_func: Callable[P, R]) -> Callable[P, R]:
         """Wrap the ``decorated_func`` in a trampoline.
-        The trampoline forwards calls based on the MUTANT_UNDER_TEST environment variable,
-        either to a copy of the original method,
+        The trampoline forwards calls based on the active mutant
+        (see ``get_mutant_under_test``), either to a copy of the original method,
         or to the currently active mutated method.
         """
 
@@ -50,7 +82,7 @@ def wrap_in_trampoline(
                 call_args = list(args[1:])
                 orig_func = getattr(args[0], orig_func.__name__)
 
-            mutant_under_test = os.environ.get("MUTANT_UNDER_TEST", "")
+            mutant_under_test = get_mutant_under_test()
 
             if mutant_under_test == "fail":
                 raise MutmutProgrammaticFailException(

--- a/tests/mutation/test_trampoline.py
+++ b/tests/mutation/test_trampoline.py
@@ -5,10 +5,14 @@ The functions under test are similar to how file_mutation.py would output the mu
 
 import asyncio
 import inspect
+import os
+from unittest.mock import patch
 
 import pytest
 from typing_extensions import Self
 
+from mutmut.mutation.trampoline import get_mutant_under_test
+from mutmut.mutation.trampoline import set_mutant_under_test
 from mutmut.mutation.trampoline import wrap_in_trampoline
 
 mutants_simple_func = {}
@@ -251,6 +255,22 @@ class TestSimpleFunc:
         # if we have the same mutant name in a different module, we should not mutate
         monkeypatch.setenv("MUTANT_UNDER_TEST", "other_test_trampoline.simple_func__mutmut_1")
         assert simple_func(2, 3) == 5, "Should call mutated function"
+
+    def test_trampoline_survives_cleared_environ(self):
+        # Tests that scrub os.environ (patch.dict(..., clear=True)) used to
+        # make the trampoline fall back to the original function. See #511.
+        set_mutant_under_test("test_trampoline.simple_func__mutmut_1")
+        try:
+            with patch.dict(os.environ, {"IN_DOCKER": "1"}, clear=True):
+                assert "MUTANT_UNDER_TEST" not in os.environ
+                assert simple_func(2, 3) == -1, "Should still call mutated function"
+        finally:
+            set_mutant_under_test(None)
+
+    def test_get_mutant_under_test_falls_back_to_env(self, monkeypatch):
+        set_mutant_under_test(None)
+        monkeypatch.setenv("MUTANT_UNDER_TEST", "from-env")
+        assert get_mutant_under_test() == "from-env"
 
 
 class TestAsyncAndGeneratorFunc:


### PR DESCRIPTION
## Summary

Fixes #511.

`patch.dict(os.environ, ..., clear=True)` was wiping `MUTANT_UNDER_TEST`, so the trampoline forwarded every call to the original function and mutants only reached by those tests were reported as survived.

As suggested in the issue, the active mutant is now also stored in process-local state. The trampoline still honors `MUTANT_UNDER_TEST` when that key is present (existing tests and callers keep working). If the key is missing, it falls back to the process-local copy.

## Test plan

- [x] `uv run pytest tests/` — 379 passed, 4 skipped
- [x] New regression: trampoline still selects the mutant after `patch.dict(os.environ, {"IN_DOCKER": "1"}, clear=True)`