### PR TITLE
Fix "pragma: no mutate" on match/case headers being silently ignored

### DIFF
--- a/src/mutmut/mutation/pragma_handling.py
+++ b/src/mutmut/mutation/pragma_handling.py
@@ -180,12 +180,12 @@ class PragmaVisitor(cst.CSTVisitor):
 
     def _scan_body_stmts(
         self,
-        body: Sequence[cst.BaseStatement | cst.BaseCompoundStatement | cst.SimpleStatementLine],
+        body: Sequence[cst.BaseStatement | cst.BaseCompoundStatement | cst.SimpleStatementLine | cst.MatchCase],
     ) -> None:
         """Scan ``leading_lines`` of each statement for standalone pragmas.
 
-        Shared by ``visit_Module`` (module-level body) and
-        ``visit_IndentedBlock`` (block-level body)."""
+        Shared by ``visit_Module`` (module-level body), ``visit_IndentedBlock``
+        (block-level body) and ``visit_Match`` (the ``case`` clauses)."""
         block_from_idx: int | None = None
         for i, stmt in enumerate(body):
             found = self._scan_empty_lines(getattr(stmt, "leading_lines", []))
@@ -265,7 +265,26 @@ class PragmaVisitor(cst.CSTVisitor):
         self._visit_compound_header(node)
         return True
 
-    def visit_Match(self, node: cst.CSTNode) -> bool | None:
+    def visit_Match(self, node: cst.Match) -> bool | None:
+        # Unlike If/For/While/... a `Match` node has no `body` attribute: its
+        # `cases` are a plain sequence of `MatchCase`, not an IndentedBlock, so
+        # a trailing comment on the `match ...:` line lives directly on
+        # `whitespace_after_colon` instead.
+        tok = _parse_pragma_token(node.whitespace_after_colon.comment)
+        if tok is not None:
+            node_line = self.get_metadata(PositionProvider, node).start.line
+            if tok == "block":
+                node_pos = self.get_metadata(PositionProvider, node)
+                self.ignore_node_lines.add(node_line)
+                self.ignore_node_lines.update(range(node_pos.start.line, node_pos.end.line + 1))
+            else:
+                self.no_mutate_lines.add(node_line)
+
+        self._scan_body_stmts(node.cases)
+        self._scan_empty_lines(node.footer)
+        return True
+
+    def visit_MatchCase(self, node: cst.MatchCase) -> bool | None:
         self._visit_compound_header(node)
         return True
 

--- a/tests/mutation/test_mutation.py
+++ b/tests/mutation/test_mutation.py
@@ -599,6 +599,79 @@ def buzz(val=1):
     assert "return val + 1" in mutated_code
 
 
+def test_pragma_no_mutate_on_match_case_guard():
+    """A pragma on a `case ... if guard:` line suppresses mutation of the
+    guard expression, e.g. `n > 0` becoming `n >= 0`."""
+    source = """
+def classify(x):
+    match x:
+        case 1:
+            return 10
+        case n if n > 0:  # pragma: no mutate
+            return 20
+        case _:
+            return 30
+""".strip()
+    mutated_code = mutated_module(source)
+    assert "x_classify__mutmut_orig" in mutated_code
+    assert "n >= 0" not in mutated_code
+    assert "n > 1" not in mutated_code
+
+
+def test_pragma_no_mutate_on_match_case_single_line():
+    source = """
+def classify(x):
+    match x:
+        case 1: return 10  # pragma: no mutate
+        case _: return 30
+""".strip()
+    mutated_code = mutated_module(source)
+    assert "x_classify__mutmut_orig" in mutated_code
+    assert "return 11" not in mutated_code
+    # the untouched case is still mutated
+    assert "return 31" in mutated_code
+
+
+def test_pragma_no_mutate_block_on_match_case():
+    """A block pragma on a `case` header suppresses mutation of that case's
+    whole body, leaving sibling cases mutable."""
+    source = """
+def classify(x):
+    match x:
+        case n if n > 0:  # pragma: no mutate block
+            return n + 1
+        case _:
+            return 0
+""".strip()
+    mutated_code = mutated_module(source)
+    assert "x_classify__mutmut_orig" in mutated_code
+    assert "n >= 0" not in mutated_code
+    assert "n + 2" not in mutated_code
+    # the untouched case is still mutated
+    assert "return 1" in mutated_code
+
+
+def test_pragma_no_mutate_block_on_match_does_not_affect_other_functions():
+    source = """
+def skipped(x):
+    match x:  # pragma: no mutate block
+        case n if n > 0:
+            return n + 1
+        case _:
+            return 0
+
+def mutated(x):
+    match x:
+        case n if n > 0:
+            return n + 1
+        case _:
+            return 0
+""".strip()
+    mutated_code = mutated_module(source)
+    assert "x_skipped__mutmut" not in mutated_code
+    assert "x_mutated__mutmut_orig" in mutated_code
+
+
 def test_pragma_no_mutate_block_inline_if_allows_elif():
     """Inline block pragma on an if-statement suppresses only that branch;
     the elif/else branches remain mutable because they exit the if scope."""

--- a/tests/mutation/test_pragma_handling.py
+++ b/tests/mutation/test_pragma_handling.py
@@ -113,6 +113,87 @@ def foo():
         assert ignored_code.ignore_node_lines == set()
 
 
+class TestMatchCasePragma:
+    """Tests for pragmas on `match` and `case` headers."""
+
+    def test_no_mutate_on_case(self):
+        source = """
+def foo(tok):
+    match tok:
+        case 1:  # pragma: no mutate
+            return 10
+        case _:
+            raise Exception("nope")
+"""
+        ignored_code = _parse_ignored_code("test.py", source)
+        assert ignored_code.no_mutate_lines == {4}
+        assert ignored_code.ignore_node_lines == set()
+
+    def test_no_mutate_on_match(self):
+        source = """
+def foo(tok):
+    match tok:  # pragma: no mutate
+        case 1:
+            return 10
+"""
+        ignored_code = _parse_ignored_code("test.py", source)
+        assert ignored_code.no_mutate_lines == {3}
+        assert ignored_code.ignore_node_lines == set()
+
+    def test_no_mutate_block_on_case(self):
+        source = """
+def foo(tok):
+    match tok:
+        case 1:  # pragma: no mutate block
+            return 10
+            return 11
+        case _:
+            raise Exception("nope")
+"""
+        ignored_code = _parse_ignored_code("test.py", source)
+        assert ignored_code.no_mutate_lines == set()
+        assert ignored_code.ignore_node_lines == {4, 5, 6}
+
+    def test_no_mutate_block_on_match(self):
+        source = """
+def foo(tok):
+    match tok:  # pragma: no mutate block
+        case 1:
+            return 10
+        case _:
+            raise Exception("nope")
+    return -1
+"""
+        ignored_code = _parse_ignored_code("test.py", source)
+        assert ignored_code.no_mutate_lines == set()
+        assert ignored_code.ignore_node_lines == {3, 4, 5, 6, 7}
+
+    def test_single_line_case_body(self):
+        """case body is a SimpleStatementSuite."""
+        source = """
+def foo(tok):
+    match tok:
+        case 1: return 10  # pragma: no mutate
+        case _: raise Exception("nope")
+"""
+        ignored_code = _parse_ignored_code("test.py", source)
+        assert ignored_code.no_mutate_lines == {4}
+        assert ignored_code.ignore_node_lines == set()
+
+    def test_only_matching_case_is_ignored(self):
+        source = """
+def foo(tok):
+    match tok:
+        case 1:  # pragma: no mutate
+            return 10
+        case 2:
+            return 20
+"""
+        ignored_code = _parse_ignored_code("test.py", source)
+        assert ignored_code.no_mutate_lines == {4}
+        assert ignored_code.ignore_node_lines == set()
+
+
 class TestBlockPragma:
     """Tests for # pragma: no mutate block."""
 


### PR DESCRIPTION
visit_Match incorrectly assumed that Match has the same structure as an if/elif/else statement and the code was missing a visit_MatchCase to handle individual case statements:

- fix visit_Match, add visit_MatchCase
- add corresponding parser unit tests
- add corresponding e2e mutation tests

Disclaimer: I generated this fix and the corresponding unit tests with claude Sonnet. I reviewed extensively both the patch and the tests.