### PR TITLE
Honour 'pragma: no mutate block' on else/except/finally arms

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ~~~~~~~~~~
 
+* Fix ``# pragma: no mutate block`` being silently ignored when placed on an ``else``, ``except``, ``except*`` or ``finally`` header, and on the ``try`` line of a ``try``/``except*``
+
 * Fix mutants being reported as survived when a test uses ``patch.dict(os.environ, ..., clear=True)`` (`#511`)
 
 * Fix `mutate_only_covered_lines` mutating code that coverage.py excludes from measurement (`# pragma: no cover`, `exclude_lines`, `exclude_also`). Such lines are reported as covered when they run, so they used to produce mutants that could only ever survive

--- a/src/mutmut/mutation/pragma_handling.py
+++ b/src/mutmut/mutation/pragma_handling.py
@@ -257,6 +257,29 @@ class PragmaVisitor(cst.CSTVisitor):
         self._visit_compound_header(node)
         return True
 
+    def visit_TryStar(self, node: cst.TryStar) -> bool | None:
+        self._visit_compound_header(node)
+        return True
+
+    # ``else``, ``except``, ``except*`` and ``finally`` are separate nodes owning
+    # their own suite, so a pragma on their header line reaches none of the
+    # visitors above.
+    def visit_Else(self, node: cst.Else) -> bool | None:
+        self._visit_compound_header(node)
+        return True
+
+    def visit_ExceptHandler(self, node: cst.ExceptHandler) -> bool | None:
+        self._visit_compound_header(node)
+        return True
+
+    def visit_ExceptStarHandler(self, node: cst.ExceptStarHandler) -> bool | None:
+        self._visit_compound_header(node)
+        return True
+
+    def visit_Finally(self, node: cst.Finally) -> bool | None:
+        self._visit_compound_header(node)
+        return True
+
     def visit_FunctionDef(self, node: cst.FunctionDef) -> bool | None:
         self._visit_compound_header(node)
         return True

--- a/tests/mutation/test_pragma_handling.py
+++ b/tests/mutation/test_pragma_handling.py
@@ -230,6 +230,64 @@ this line has zero indentation
         ignored_code = _parse_ignored_code("test.py", source)
         assert ignored_code.no_mutate_lines == {3, 4, 5, 6, 7}
 
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pytest.param(
+                "\nif condition:\n    x = 1\nelse:  # pragma: no mutate block\n    y = 2\n",
+                id="if-else",
+            ),
+            pytest.param(
+                "\nfor item in items:\n    x = 1\nelse:  # pragma: no mutate block\n    y = 2\n",
+                id="for-else",
+            ),
+            pytest.param(
+                "\nwhile condition:\n    x = 1\nelse:  # pragma: no mutate block\n    y = 2\n",
+                id="while-else",
+            ),
+            pytest.param(
+                "\ntry:\n    x = 1\nexcept ValueError:  # pragma: no mutate block\n    y = 2\n",
+                id="except",
+            ),
+            pytest.param(
+                "\ntry:\n    x = 1\nexcept* ValueError:  # pragma: no mutate block\n    y = 2\n",
+                id="except-star",
+            ),
+            pytest.param(
+                "\ntry:\n    x = 1\nfinally:  # pragma: no mutate block\n    y = 2\n",
+                id="finally",
+            ),
+        ],
+    )
+    def test_inline_on_compound_arm(self, source):
+        """``else``, ``except``, ``except*`` and ``finally`` own their own suite,
+        so they need their own visitors."""
+        ignored_code = _parse_ignored_code("test.py", source)
+        assert ignored_code.no_mutate_lines == set()
+        assert ignored_code.ignore_node_lines == {4, 5}
+
+    def test_inline_on_try_with_except_star(self):
+        """``try``/``except*`` parses as ``TryStar``, not ``Try``."""
+        source = """
+try:  # pragma: no mutate block
+    x = 1
+except* ValueError:
+    y = 2
+"""
+        ignored_code = _parse_ignored_code("test.py", source)
+        assert ignored_code.ignore_node_lines == {2, 3}
+
+    def test_inline_on_arm_does_not_ignore_siblings(self):
+        source = """
+if condition:
+    x = 1
+else:  # pragma: no mutate block
+    y = 2
+z = 3
+"""
+        ignored_code = _parse_ignored_code("test.py", source)
+        assert ignored_code.ignore_node_lines == {4, 5}
+
 
 class TestSelectionPragma:
     """Tests for # pragma: no mutate start / end pairs."""

--- a/tests/mutation/test_pragma_handling.py
+++ b/tests/mutation/test_pragma_handling.py
@@ -234,27 +234,57 @@ this line has zero indentation
         "source",
         [
             pytest.param(
-                "\nif condition:\n    x = 1\nelse:  # pragma: no mutate block\n    y = 2\n",
+                """
+if condition:
+    x = 1
+else:  # pragma: no mutate block
+    y = 2
+""",
                 id="if-else",
             ),
             pytest.param(
-                "\nfor item in items:\n    x = 1\nelse:  # pragma: no mutate block\n    y = 2\n",
+                """
+for item in items:
+    x = 1
+else:  # pragma: no mutate block
+    y = 2
+""",
                 id="for-else",
             ),
             pytest.param(
-                "\nwhile condition:\n    x = 1\nelse:  # pragma: no mutate block\n    y = 2\n",
+                """
+while condition:
+    x = 1
+else:  # pragma: no mutate block
+    y = 2
+""",
                 id="while-else",
             ),
             pytest.param(
-                "\ntry:\n    x = 1\nexcept ValueError:  # pragma: no mutate block\n    y = 2\n",
+                """
+try:
+    x = 1
+except ValueError:  # pragma: no mutate block
+    y = 2
+""",
                 id="except",
             ),
             pytest.param(
-                "\ntry:\n    x = 1\nexcept* ValueError:  # pragma: no mutate block\n    y = 2\n",
+                """
+try:
+    x = 1
+except* ValueError:  # pragma: no mutate block
+    y = 2
+""",
                 id="except-star",
             ),
             pytest.param(
-                "\ntry:\n    x = 1\nfinally:  # pragma: no mutate block\n    y = 2\n",
+                """
+try:
+    x = 1
+finally:  # pragma: no mutate block
+    y = 2
+""",
                 id="finally",
             ),
         ],


### PR DESCRIPTION
`_visit_compound_header` is only reachable from `visit_If` / `For` / `While` / `With` / `Try` / `FunctionDef` / `ClassDef` / `Match`. In libcst, `else`, `except`, `except*` and `finally` are separate nodes owning their own suite, so a `# pragma: no mutate block` on one of those header lines reaches no visitor and is dropped — silently, which is the bad part: you mark an error branch as skipped and it gets mutated anyway.

Measured on `main`, `ignore_node_lines` for a pragma on each header:

```
if       [2,3]   works        else (if/for/while/try)   []   ignored
elif     [4,5]   works        except                    []   ignored
while    [2,3]   works        except*                   []   ignored
with     [2,3]   works        finally                   []   ignored
try      [2,3]   works        try  (of a try/except*)   []   ignored
```

`elif` works because it parses as a nested `If`; the `else` one line below it does not. The last row is the same source line behaving differently depending on whether a later handler writes `except` or `except*` — `try`/`except*` parses as `TryStar`, and there is no `visit_TryStar`.

README:291 says the block pragma "works on any compound statement -- functions, classes, ``if``/``elif``/``else``, loops, context managers, etc."; README:345 extends it to `for`/`else`, `while`/`else` and `try`/`except`/`finally`.

Five visitors added, in the existing style. **`Match`/`MatchCase` deliberately untouched** — #554 is fixing that, and I did not want to duplicate it. I cherry-picked this commit onto `pull/554/head`: it auto-merges with **zero conflicts** and the combined tree passes 50/50 in `test_pragma_handling.py`. Land them in either order.

Checked by reverting: with `pragma_handling.py` back at `main` and the tests kept, exactly the 8 new tests fail and the other 36 pass. Adding only `visit_Else` still fails 4 of them (`except`, `except*`, `finally`, `TryStar`), so each visitor is pinned rather than carried by its neighbours. A sibling-leak case asserts the statement after the `else` block stays mutable.

`uv run pytest` gives 387 passed / 2 failed against 379 passed / 2 failed on `main`, same venv after `uv sync` (three consecutive runs each). The two failures are the `test_e2e_type_checking` snapshot tests and are identical on both trees. `test_safe_setproctitle` is flaky here on macOS — it failed in one earlier run of each tree and in none of the three above. `ruff check` and `ruff format` clean at the pinned 0.15.7; `mypy` reports 19 errors, all in `__main__.py`, none in the files touched, identical to `main`. I did **not** run `./scripts/run_tests.sh` in the Linux container.

Found by enumerating the `visit_*` methods against the libcst node types that own a suite, then probing each. AI assistance: this change and its tests were drafted with Claude Opus 5 (`claude-opus-5`). The commands and numbers above were run locally.
