### PR TITLE
test: the stats collector counts only the call phase

### DIFF
--- a/tests/test_pytest_runner_stats.py
+++ b/tests/test_pytest_runner_stats.py
@@ -1,0 +1,40 @@
+"""The stats collector must ignore the setup and teardown report durations (#544)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import mutmut
+from mutmut.__main__ import PytestRunner
+
+
+def test_stats_collector_records_only_the_call_phase(tmp_path, monkeypatch):
+    # The collector is a class local to run_stats(); intercept the plugin that
+    # run_stats() hands to pytest instead of running pytest, then feed the hooks
+    # synthetic reports so the assertion is about the guard, not about timing.
+    captured = []
+
+    def fake_execute_pytest(self, params, **kwargs):
+        captured.extend(kwargs["plugins"])
+        return 0
+
+    monkeypatch.setattr(PytestRunner, "execute_pytest", fake_execute_pytest)
+    (tmp_path / "src").mkdir()  # mutmut's config discovery needs a source dir to exist
+    (tmp_path / "mutants").mkdir()
+    monkeypatch.chdir(tmp_path)
+    mutmut._reset_globals()
+    try:
+        PytestRunner().run_stats(tests=[])
+        (collector,) = captured
+
+        nodeid = "test_example.py::test_fast"
+        item = SimpleNamespace(nodeid=nodeid)
+        collector.pytest_runtest_logstart(nodeid, location=None)
+        for when, duration in (("setup", 0.4), ("call", 0.01), ("teardown", 0.5)):
+            collector.pytest_runtest_makereport(item, SimpleNamespace(when=when, duration=duration))
+
+        assert mutmut.duration_by_test[nodeid] == pytest.approx(0.01)
+    finally:
+        mutmut._reset_globals()


### PR DESCRIPTION
5f3911d1 fixed #544: `pytest_runtest_makereport` fires for setup, call and teardown, and the stats collector was adding all three to `duration_by_test`, inflating the recorded duration used by the per-mutant timeout calculation. It merged without a test.

This adds one. The collector is local to `run_stats()`, so the test intercepts the plugin `run_stats()` hands to pytest and feeds its hooks synthetic setup/call/teardown reports; no sleeps, no wall clock.

Against `dc58270d` (the fix's parent) the test fails with `0.91`, because setup, call and teardown are summed. Against `5f3911d1` it passes with `0.01`.

Full-suite result on the fixed tree: 359 passed, 1 skipped, 2 environment-dependent failures (missing `pyrefly`; a platform probe whose expected subprocess crash did not occur here).
