### PR TITLE
Make trampoline hits cheap during stats collection

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,10 @@ Changelog
 Unreleased
 ~~~~~~~~~~
 
+* Performance: faster stats collection on big test suites. Recording which functions a test reaches no longer resolves file paths on every call to a mutated function
+
+* Fix ``max_stack_depth`` crashing stats collection on frames without a source file, such as a ``@dataclass`` generated ``__init__``
+
 * Fix ``# pragma: no mutate block`` being silently ignored when placed on an ``else``, ``except``, ``except*`` or ``finally`` header, and on the ``try`` line of a ``try``/``except*``
 
 * Fix mutants being reported as survived when a test uses ``patch.dict(os.environ, ..., clear=True)`` (`#511`)

--- a/src/mutmut/__main__.py
+++ b/src/mutmut/__main__.py
@@ -84,21 +84,60 @@ from mutmut.workers.timeout import register_timeout
 # TODO: pragma no mutate should end up in `skipped` category
 
 
+FRAME_OTHER = 0
+FRAME_MUTATED_SOURCE = 1
+FRAME_TEST_FRAMEWORK = 2
+
+# co_filename -> FRAME_* classification. Filenames come from code objects, so there are only
+# as many distinct keys as loaded modules; classifying one costs a path resolution.
+_frame_classification_cache: dict[str, int] = {}
+
+
+def classify_frame_filename(filename: str) -> int:
+    """Classify a stack frame by its code object's filename, for ``max_stack_depth``.
+
+    Relative filenames are not cached because their meaning depends on the working directory,
+    which tests may change.
+    """
+    cached = _frame_classification_cache.get(filename)
+    if cached is not None:
+        return cached
+
+    if "pytest" in filename or "hammett" in filename or "unittest" in filename:
+        result = FRAME_TEST_FRAMEWORK
+    elif filename.startswith("<"):
+        # <string>, <frozen ...>: not a file
+        result = FRAME_OTHER
+    else:
+        try:
+            file_path = Path(filename).resolve()
+        except (OSError, ValueError):
+            result = FRAME_OTHER
+        else:
+            parents = file_path.parents
+            result = (
+                FRAME_MUTATED_SOURCE
+                if any(path in parents for path in config().resolved_mutated_source_paths)
+                else FRAME_OTHER
+            )
+
+    if os.path.isabs(filename):
+        _frame_classification_cache[filename] = result
+    return result
+
+
 def record_trampoline_hit(name: str, caller: str | None = None) -> None:
     assert not name.startswith("src."), "Failed trampoline hit. Module name starts with `src.`, which is invalid"
-
-    mutated_source_paths = config().resolved_mutated_source_paths
 
     if config().max_stack_depth != -1:
         f = inspect.currentframe()
         c = config().max_stack_depth
         while c and f:
-            filename = f.f_code.co_filename
+            classification = classify_frame_filename(f.f_code.co_filename)
             f = f.f_back
-            if "pytest" in filename or "hammett" in filename or "unittest" in filename:
+            if classification == FRAME_TEST_FRAMEWORK:
                 break
-            file_path = Path(filename).resolve(strict=True)
-            if any(path in file_path.parents for path in mutated_source_paths):
+            if classification == FRAME_MUTATED_SOURCE:
                 # only include stack frames of user-code; exclude mutmut and 3rd library stack frames
                 c -= 1
 
@@ -269,6 +308,13 @@ def write_all_mutants_to_file(*, out: TextIOBase, source: str, filename: Path) -
     return mutated_file
 
 
+def _set_dependency_depth(depth: int) -> None:
+    """Refresh the trampoline's cached copy of ``MUTMUT_DEPENDENCY_DEPTH`` for this process."""
+    from mutmut.mutation.trampoline import set_dependency_depth  # avoids an import cycle
+
+    set_dependency_depth(depth)
+
+
 def _set_mutant_under_test(name: str) -> None:
     """Activate a mutant in process-local state and the environment.
 
@@ -367,6 +413,7 @@ def run_stats_collection(runner: TestRunner, tests: Iterable[str] | None = None)
     os.environ["PY_IGNORE_IMPORTMISMATCH"] = "1"
     depth = config().dependency_tracking_depth
     os.environ["MUTMUT_DEPENDENCY_DEPTH"] = str(depth)
+    _set_dependency_depth(depth)
     start_cpu_time = process_time()
 
     with CatchOutput(spinner_title="Running stats") as output_catcher:

--- a/src/mutmut/mutation/trampoline.py
+++ b/src/mutmut/mutation/trampoline.py
@@ -9,7 +9,9 @@ from typing import TypeVar
 
 from mutmut.__main__ import MutmutProgrammaticFailException
 from mutmut.__main__ import record_trampoline_hit
+from mutmut.configuration import config
 from mutmut.core import MutmutCallStack
+from mutmut.state import state
 from mutmut.utils.format_utils import mangled_name_from_mutant_name
 
 TReturn = TypeVar("TReturn")
@@ -51,11 +53,46 @@ def get_mutant_under_test() -> str:
     If the key is missing (for example after ``patch.dict(..., clear=True)``),
     fall back to the process-local copy set by ``set_mutant_under_test``.
     """
-    if "MUTANT_UNDER_TEST" in os.environ:
-        return os.environ["MUTANT_UNDER_TEST"]
+    from_environ = os.environ.get("MUTANT_UNDER_TEST")
+    if from_environ is not None:
+        return from_environ
     if _mutant_under_test is not None:
         return _mutant_under_test
     return ""
+
+
+# Maximum call depth for dependency tracking during stats collection. ``None`` means
+# "not set yet, read ``MUTMUT_DEPENDENCY_DEPTH``". Cached because the trampoline is on the
+# hot path of every call to every mutated function while stats are collected.
+_dependency_depth: int | None = None
+
+
+def set_dependency_depth(depth: int | None) -> None:
+    global _dependency_depth
+    _dependency_depth = depth
+
+
+def _get_dependency_depth() -> int:
+    global _dependency_depth
+    if _dependency_depth is None:
+        _dependency_depth = int(os.environ.get("MUTMUT_DEPENDENCY_DEPTH", "-1"))
+    return _dependency_depth
+
+
+def _needs_recording(name: str, caller: str | None) -> bool:
+    """Whether ``record_trampoline_hit`` could still learn something from this call.
+
+    The hit set is per test (cleared at teardown) and the dependency edges are per function,
+    so once both are known, the (expensive) stack inspection in ``record_trampoline_hit``
+    cannot change the outcome and is skipped.
+    """
+    current = state()
+    if name not in current._stats:
+        return True
+    if caller is None or not config().track_dependencies:
+        return False
+    callers = current.function_dependencies.get(name)
+    return callers is None or caller not in callers
 
 
 def wrap_in_trampoline(
@@ -68,7 +105,11 @@ def wrap_in_trampoline(
         or to the currently active mutated method.
         """
 
+        # qualified name of the original function, computed on the first stats hit
+        cached_qual_name: str | None = None
+
         def trampoline(*args: P.args, **kwargs: P.kwargs) -> R:
+            nonlocal cached_qual_name
             # orig_func is the non-mutated implementation.
             # we do not use `decorated_func` directly,
             # because using the func via SomeClass.foo makes it easier for classmethod wrapping
@@ -90,11 +131,14 @@ def wrap_in_trampoline(
                 )
 
             if mutant_under_test == "stats":
-                orig_qual_name = f"{orig_func.__module__}.{mangled_name_from_mutant_name(orig_func.__name__)}"
+                if cached_qual_name is None:
+                    cached_qual_name = f"{orig_func.__module__}.{mangled_name_from_mutant_name(orig_func.__name__)}"
+                orig_qual_name = cached_qual_name
                 caller_name, depth = MutmutCallStack.get()
-                max_depth = int(os.environ.get("MUTMUT_DEPENDENCY_DEPTH", "-1"))
+                max_depth = _get_dependency_depth()
                 if max_depth == -1 or depth < max_depth:
-                    record_trampoline_hit(orig_qual_name, caller=caller_name)
+                    if _needs_recording(orig_qual_name, caller_name):
+                        record_trampoline_hit(orig_qual_name, caller=caller_name)
                     token = MutmutCallStack.set((orig_qual_name, depth + 1))
                     try:
                         return orig_func(*call_args, **kwargs)

--- a/tests/mutation/test_stats_recording.py
+++ b/tests/mutation/test_stats_recording.py
@@ -1,0 +1,202 @@
+"""Recording which functions a test reaches (stats collection) must be cheap and robust."""
+
+import os
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+import mutmut.__main__
+import mutmut.mutation.trampoline as trampoline_module
+from mutmut.__main__ import FRAME_MUTATED_SOURCE
+from mutmut.__main__ import FRAME_OTHER
+from mutmut.__main__ import FRAME_TEST_FRAMEWORK
+from mutmut.__main__ import _frame_classification_cache
+from mutmut.__main__ import classify_frame_filename
+from mutmut.__main__ import record_trampoline_hit
+from mutmut.configuration import Config
+from mutmut.mutation.trampoline import _get_dependency_depth
+from mutmut.mutation.trampoline import _needs_recording
+from mutmut.mutation.trampoline import set_dependency_depth
+from mutmut.mutation.trampoline import set_mutant_under_test
+from mutmut.mutation.trampoline import wrap_in_trampoline
+from mutmut.state import reset_state
+from mutmut.state import state
+
+
+def _config(monkeypatch, project_dir: Path, *, max_stack_depth: int = -1, track_dependencies: bool = True) -> Mock:
+    cfg = Mock(spec=Config)
+    cfg.max_stack_depth = max_stack_depth
+    cfg.source_paths = [Path("src")]
+    cfg.resolved_mutated_source_paths = [project_dir / "mutants" / "src"]
+    cfg.track_dependencies = track_dependencies
+    monkeypatch.setattr(mutmut.__main__, "config", lambda: cfg)
+    monkeypatch.setattr(trampoline_module, "config", lambda: cfg)
+    return cfg
+
+
+@pytest.fixture
+def project_dir() -> Iterator[Path]:
+    """A scratch directory whose path does not contain "pytest".
+
+    Frames from files whose path contains "pytest" (or "unittest") are treated as test
+    framework frames, and pytest's own tmp_path lives under /tmp/pytest-of-<user>/."""
+    with tempfile.TemporaryDirectory(prefix="mutmut-stats-") as directory:
+        yield Path(directory)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_state() -> Iterator[None]:
+    reset_state()
+    _frame_classification_cache.clear()
+    set_dependency_depth(None)
+    yield
+    reset_state()
+    _frame_classification_cache.clear()
+    set_dependency_depth(None)
+    set_mutant_under_test("")
+
+
+class TestClassifyFrameFilename:
+    def test_mutated_source_test_framework_and_other_files(self, monkeypatch, project_dir):
+        _config(monkeypatch, project_dir)
+        mutated = project_dir / "mutants" / "src" / "pkg" / "mod.py"
+        mutated.parent.mkdir(parents=True)
+        mutated.touch()
+        elsewhere = project_dir / "lib" / "other.py"
+        elsewhere.parent.mkdir()
+        elsewhere.touch()
+
+        assert classify_frame_filename(str(mutated)) == FRAME_MUTATED_SOURCE
+        assert classify_frame_filename(str(elsewhere)) == FRAME_OTHER
+        assert classify_frame_filename("/site-packages/_pytest/python.py") == FRAME_TEST_FRAMEWORK
+        assert classify_frame_filename("/site-packages/unittest/case.py") == FRAME_TEST_FRAMEWORK
+
+    def test_frames_without_a_file_do_not_raise(self, monkeypatch, project_dir):
+        _config(monkeypatch, project_dir)
+
+        assert classify_frame_filename("<string>") == FRAME_OTHER
+        assert classify_frame_filename("<frozen importlib._bootstrap>") == FRAME_OTHER
+        assert classify_frame_filename(str(project_dir / "deleted.py")) == FRAME_OTHER
+
+    def test_absolute_filenames_are_cached_relative_ones_are_not(self, monkeypatch, project_dir):
+        cfg = _config(monkeypatch, project_dir)
+        absolute = str(project_dir / "mutants" / "src" / "mod.py")
+        classify_frame_filename(absolute)
+        classify_frame_filename("src/mod.py")
+
+        assert absolute in _frame_classification_cache
+        assert "src/mod.py" not in _frame_classification_cache
+
+        # the cache answers without looking at the configuration again
+        cfg.resolved_mutated_source_paths = []
+        assert classify_frame_filename(absolute) == FRAME_MUTATED_SOURCE
+
+
+class TestRecordTrampolineHit:
+    def test_records_from_code_without_a_file(self, monkeypatch, project_dir):
+        """Frames whose co_filename is not a file (compiled from a string) used to raise."""
+        _config(monkeypatch, project_dir, max_stack_depth=3)
+        namespace: dict[str, object] = {"record_trampoline_hit": record_trampoline_hit}
+        exec(compile("def hit():\n    record_trampoline_hit('mod.x_foo')\n", "<string>", "exec"), namespace)
+
+        namespace["hit"]()  # type: ignore[operator]
+
+        assert "mod.x_foo" in state()._stats
+
+    def test_counts_only_frames_from_mutated_sources_towards_the_depth(self, monkeypatch, project_dir):
+        _config(monkeypatch, project_dir, max_stack_depth=2)
+        module_path = project_dir / "mutants" / "src" / "deep.py"
+        module_path.parent.mkdir(parents=True)
+        module_path.write_text(
+            "def level3():\n"
+            "    record_trampoline_hit('deep.x_level3')\n"
+            "def level2():\n"
+            "    level3()\n"
+            "def level1():\n"
+            "    level2()\n"
+        )
+        namespace: dict[str, object] = {"record_trampoline_hit": record_trampoline_hit}
+        exec(compile(module_path.read_text(), str(module_path), "exec"), namespace)
+
+        namespace["level1"]()  # type: ignore[operator]
+
+        # three frames of mutated source lie between the hit and this test: deeper than allowed
+        assert "deep.x_level3" not in state()._stats
+
+        namespace["level3"]()  # type: ignore[operator]
+        assert "deep.x_level3" in state()._stats
+
+
+class TestNeedsRecording:
+    def test_first_hit_is_always_recorded(self, monkeypatch, project_dir):
+        _config(monkeypatch, project_dir)
+        assert _needs_recording("mod.x_foo", None)
+        assert _needs_recording("mod.x_foo", "mod.x_caller")
+
+    def test_known_hit_and_known_caller_are_skipped(self, monkeypatch, project_dir):
+        _config(monkeypatch, project_dir)
+        state()._stats.add("mod.x_foo")
+        state().function_dependencies["mod.x_foo"].add("mod.x_caller")
+
+        assert not _needs_recording("mod.x_foo", None)
+        assert not _needs_recording("mod.x_foo", "mod.x_caller")
+        assert _needs_recording("mod.x_foo", "mod.x_other_caller")
+
+    def test_callers_are_irrelevant_when_dependency_tracking_is_off(self, monkeypatch, project_dir):
+        _config(monkeypatch, project_dir, track_dependencies=False)
+        state()._stats.add("mod.x_foo")
+
+        assert not _needs_recording("mod.x_foo", "mod.x_caller")
+
+
+class TestDependencyDepth:
+    def test_explicit_value_wins_over_the_environment(self, monkeypatch):
+        monkeypatch.setenv("MUTMUT_DEPENDENCY_DEPTH", "5")
+        set_dependency_depth(2)
+        assert _get_dependency_depth() == 2
+
+    def test_environment_is_read_once(self, monkeypatch):
+        monkeypatch.setenv("MUTMUT_DEPENDENCY_DEPTH", "5")
+        assert _get_dependency_depth() == 5
+        monkeypatch.delenv("MUTMUT_DEPENDENCY_DEPTH")
+        assert _get_dependency_depth() == 5
+
+    def test_defaults_to_unlimited(self, monkeypatch):
+        monkeypatch.delenv("MUTMUT_DEPENDENCY_DEPTH", raising=False)
+        assert _get_dependency_depth() == -1
+
+
+mutants_counted = {}
+
+
+@wrap_in_trampoline(mutants_counted)
+def counted(a: int) -> int:
+    return a
+
+
+def x_counted__mutmut_orig(a: int) -> int:
+    return a
+
+
+mutants_counted["_mutmut_orig"] = x_counted__mutmut_orig
+
+
+def test_trampoline_records_a_function_once_per_test(monkeypatch, project_dir):
+    _config(monkeypatch, project_dir)
+    recorded: list[tuple[str, str | None]] = []
+
+    def fake_record(name: str, caller: str | None = None) -> None:
+        recorded.append((name, caller))
+        state()._stats.add(name)
+
+    monkeypatch.setattr(trampoline_module, "record_trampoline_hit", fake_record)
+    set_mutant_under_test("stats")
+
+    for i in range(100):
+        assert counted(i) == i
+
+    assert recorded == [(f"{__name__}.x_counted", None)]
+    assert os.environ["MUTANT_UNDER_TEST"] == "stats"


### PR DESCRIPTION
During stats collection every call to a mutated function went through record_trampoline_hit, which resolved the path of each inspected frame with Path.resolve(strict=True) to decide whether the frame is user code. On a 14k-test suite this made the instrumented run about 7x slower than a plain run of the same tests, and it raised FileNotFoundError for frames whose co_filename is not a file, for example the "<string>" of a dataclass-generated __init__, which aborted the whole run.

- Skip record_trampoline_hit when the function is already recorded for the current test and the caller edge is already known: the hit set is cleared per test, so later calls cannot change the outcome.
- Cache the per-filename classification (mutated source, test framework, other). Filenames come from code objects, so the cache is bounded by the number of loaded modules. Relative filenames are not cached because they depend on the working directory. Frames without a file count as "other" instead of raising.
- Compute the trampoline's qualified name once per function and read MUTMUT_DEPENDENCY_DEPTH once instead of on every call.
- get_mutant_under_test does one os.environ lookup instead of two.

Tests cover frame classification and its cache, the depth counting, recording from code without a file, once-per-test recording, and the cached dependency depth.