### PR TITLE
Skip the clean run when the suite is already known to pass.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ~~~~~~~~~~
 
+* Performance: the clean test run is skipped right after a full stats collection or when nothing is left to test, and otherwise limited to the tests of the mutants about to be tested. The forced-fail check probes a few tests known to reach mutated functions instead of running the whole suite
+
 * Fix ``# pragma: no mutate block`` being silently ignored when placed on an ``else``, ``except``, ``except*`` or ``finally`` header, and on the ``try`` line of a ``try``/``except*``
 
 * Fix mutants being reported as survived when a test uses ``patch.dict(os.environ, ..., clear=True)`` (`#511`)

--- a/src/mutmut/__main__.py
+++ b/src/mutmut/__main__.py
@@ -26,6 +26,7 @@ import resource
 import shutil
 import subprocess
 import warnings
+from collections import defaultdict
 from collections.abc import Callable
 from colorsys import hls_to_rgb
 from dataclasses import dataclass
@@ -281,11 +282,21 @@ def _set_mutant_under_test(name: str) -> None:
     set_mutant_under_test(name)
 
 
-def run_forced_fail_test(runner: TestRunner) -> None:
+def run_forced_fail_test(runner: TestRunner, tests: Iterable[str] = ()) -> None:
+    """Verify that activating mutants makes tests fail.
+
+    ``tests`` narrows the run to tests known to reach a mutated function (see
+    ``probe_tests_for_forced_fail``), which avoids collecting the whole suite. If they
+    unexpectedly pass, the whole suite is tried before giving up.
+    """
+    tests = list(tests)
     _set_mutant_under_test("fail")
     with CatchOutput(spinner_title="Running forced fail test") as catcher:
         try:
-            if runner.run_forced_fail() == 0:
+            exit_code = runner.run_forced_fail(tests=tests)
+            if exit_code == 0 and tests:
+                exit_code = runner.run_forced_fail(tests=())
+            if exit_code == 0:
                 catcher.dump_output()
                 print("FAILED: Unable to force test failures")
                 raise SystemExit(1)
@@ -293,6 +304,40 @@ def run_forced_fail_test(runner: TestRunner) -> None:
             pass
     _set_mutant_under_test("")
     print("    done")
+
+
+def probe_tests_for_forced_fail(tests: Iterable[str], limit: int = 8) -> list[str]:
+    """Up to ``limit`` tests, from different files, most likely to fail when every mutant raises.
+
+    Ranked by how many mutated functions stats collection saw a test reach; a test with a
+    single association may only be linked through an import-time hit and pass. Empty when
+    nothing suitable is known, meaning run everything."""
+    durations = state().duration_by_test
+    functions_reached: dict[str, int] = defaultdict(int)
+    for tests_of_function in state().tests_by_mangled_function_name.values():
+        for test in tests_of_function:
+            functions_reached[test] += 1
+    candidates = sorted(
+        (test for test in tests if test in durations),
+        key=lambda test: (-functions_reached[test], durations[test], test),
+    )
+    probes: list[str] = []
+    seen_files: set[str] = set()
+    for test in candidates:
+        file = test.partition("::")[0]
+        if file in seen_files:
+            continue
+        seen_files.add(file)
+        probes.append(test)
+        if len(probes) == limit:
+            break
+    return probes
+
+
+def print_skipped_phase(title: str, reason: str) -> None:
+    print_status(title, force_output=True)
+    print()
+    print(f"    skipped: {reason}")
 
 
 class CatchOutput:
@@ -704,7 +749,12 @@ def collect_or_load_stats(
     mutants_caught_by_type_checker: dict[str, Any] | None = None,
     apply_config_invalidation: bool = False,
     invalidate_stale_callers: bool = True,
-) -> None:
+) -> bool:
+    """Load cached stats or collect them. Returns True if a full stats collection ran.
+
+    A full collection runs every test (unmutated) and fails the run if any test fails, so
+    when it returns True the caller knows the suite passes and can skip the clean run.
+    """
     did_load = load_stats()
 
     force_full = False
@@ -716,6 +766,7 @@ def collect_or_load_stats(
         _refresh_change_detection_baseline()
         # Run full stats
         run_stats_collection(runner)
+        return True
     else:
         _cleanup_stale_stats()
         if config().track_dependencies and invalidate_stale_callers:
@@ -739,6 +790,26 @@ def collect_or_load_stats(
         if new_tests:
             print(f"Found {len(new_tests)} new tests, rerunning stats collection")
             run_stats_collection(runner, tests=new_tests)
+    return False
+
+
+def tests_for_mutants(mutants: Iterable[tuple[SourceFileMutationData, str, int | None]]) -> set[str]:
+    """Every test that stats collection associated with the functions of ``mutants``."""
+    tests: set[str] = set()
+    for _, mutant_name, _ in mutants:
+        key = mangled_name_from_mutant_name(mutant_name.replace("__init__.", ""))
+        tests |= state().tests_by_mangled_function_name.get(key, set())
+    return tests
+
+
+def clean_run_test_selection(relevant_tests: set[str]) -> list[str]:
+    """Which tests to hand pytest for the clean run: the relevant ids, or the configured
+    selection once the ids are a majority of the suite (returned as an empty list)."""
+    known_tests = collected_test_names()
+    # rough crossover: resolving this many ids costs more than collecting the configured paths
+    if len(relevant_tests) >= len(known_tests) / 2:
+        return []
+    return sorted(relevant_tests)
 
 
 def save_cicd_stats(source_file_mutation_data_by_path: dict[str, SourceFileMutationData]) -> None:
@@ -1007,9 +1078,7 @@ def _run(mutant_names: tuple[str, ...] | list[str], max_children: int | None) ->
     runner = PytestRunner()
     runner.prepare_main_test_run()
 
-    # TODO: run these steps only if we have mutants to test
-
-    collect_or_load_stats(
+    ran_full_stats = collect_or_load_stats(
         runner,
         mutants_caught_by_type_checker=mutants_caught_by_type_checker,
         apply_config_invalidation=True,
@@ -1019,19 +1088,31 @@ def _run(mutant_names: tuple[str, ...] | list[str], max_children: int | None) ->
 
     _check_test_to_mutant_associations(source_file_mutation_data_by_path)
 
-    _set_mutant_under_test("")
-    with CatchOutput(spinner_title="Running clean tests") as output_catcher:
-        tests = tests_for_mutant_names(mutant_names)
+    # Only mutants without a verdict (or the explicitly requested ones) are tested below, so the
+    # clean and forced-fail runs are scoped to them and skipped when there is nothing to test.
+    pending_mutants = [(m, name, result) for m, name, result in mutants if mutant_names or result is None]
+    relevant_tests = tests_for_mutants(pending_mutants)
 
-        clean_test_exit_code = runner.run_tests(mutant_name=None, tests=tests)
-        if clean_test_exit_code != 0:
-            output_catcher.dump_output()
-            print("Failed to run clean test")
-            exit(1)
-    print("    done")
+    _set_mutant_under_test("")
+    if not pending_mutants or not relevant_tests:
+        print_skipped_phase("Running clean tests", "no mutants with tests to check")
+    elif ran_full_stats:
+        # stats collection ran every test unmutated and would have stopped on a failure
+        print_skipped_phase("Running clean tests", "all tests already passed during stats collection")
+    else:
+        with CatchOutput(spinner_title="Running clean tests") as output_catcher:
+            clean_test_exit_code = runner.run_tests(mutant_name=None, tests=clean_run_test_selection(relevant_tests))
+            if clean_test_exit_code != 0:
+                output_catcher.dump_output()
+                print("Failed to run clean test")
+                exit(1)
+        print("    done")
 
     # this can't be the first thing, because it can fail deep inside pytest/django setup and then everything is destroyed
-    run_forced_fail_test(runner)
+    if not pending_mutants or not relevant_tests:
+        print_skipped_phase("Running forced fail test", "no mutants with tests to check")
+    else:
+        run_forced_fail_test(runner, tests=probe_tests_for_forced_fail(relevant_tests))
 
     runner.prepare_main_test_run()
 

--- a/src/mutmut/runners/harness.py
+++ b/src/mutmut/runners/harness.py
@@ -34,7 +34,8 @@ class TestRunner(ABC):
     def run_stats(self, *, tests: Iterable[str]) -> int:
         raise NotImplementedError()
 
-    def run_forced_fail(self) -> int:
+    def run_forced_fail(self, *, tests: Iterable[str] = ()) -> int:
+        """Run ``tests`` (all tests if empty) with every mutant forced to raise."""
         raise NotImplementedError()
 
     def prepare_main_test_run(self) -> None:
@@ -138,8 +139,8 @@ class PytestRunner(TestRunner):
             self.prepare_main_test_run()
             return int(self.execute_pytest(self._pytest_args_regular_run([])))
 
-    def run_forced_fail(self) -> int:
-        return self.run_tests(mutant_name=None, tests=[])
+    def run_forced_fail(self, *, tests: Iterable[str] = ()) -> int:
+        return self.run_tests(mutant_name=None, tests=list(tests))
 
     def list_all_tests(self) -> ListAllTestsResult:
         class TestsCollector:
@@ -191,7 +192,7 @@ class HammettRunner(TestRunner):
             )
         )
 
-    def run_forced_fail(self) -> int:
+    def run_forced_fail(self, *, tests: Iterable[str] = ()) -> int:
         import hammett
 
         return int(

--- a/tests/e2e/test_e2e_my_lib.py
+++ b/tests/e2e/test_e2e_my_lib.py
@@ -1,5 +1,10 @@
 from inline_snapshot import snapshot
 
+import mutmut
+from mutmut.__main__ import _run
+from mutmut.runners.harness import PytestRunner
+from tests.e2e.e2e_utils import E2E_PROJECTS
+from tests.e2e.e2e_utils import change_cwd
 from tests.e2e.e2e_utils import run_mutmut_on_project
 
 
@@ -122,3 +127,17 @@ def test_my_lib_result_snapshot():
             }
         }
     )
+
+
+def test_rerun_with_every_verdict_cached_runs_no_tests(monkeypatch):
+    """With nothing left to test, neither the clean run nor the forced-fail run is needed."""
+    assert run_mutmut_on_project("my_lib")
+
+    def no_tests_expected(self, *, mutant_name, tests):
+        raise AssertionError(f"unexpected test run for mutant {mutant_name!r} with tests {tests!r}")
+
+    monkeypatch.setattr(PytestRunner, "run_tests", no_tests_expected)
+
+    with change_cwd(E2E_PROJECTS / "my_lib"):
+        mutmut._reset_globals()
+        _run([], None)

--- a/tests/mutation/test_mutation.py
+++ b/tests/mutation/test_mutation.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from pathlib import Path
 from unittest.mock import Mock
+from unittest.mock import call
 from unittest.mock import patch
 
 import libcst as cst
@@ -1121,6 +1122,33 @@ def _mocked_runner_run_forced_failed(return_value=None, side_effect=None):
     runner = Mock()
     runner.run_forced_fail = Mock(return_value=return_value, side_effect=side_effect)
     return runner
+
+
+# Negate the effects of CatchOutput because it does not play nicely with capfd in GitHub Actions
+@patch.object(CatchOutput, "dump_output")
+@patch.object(CatchOutput, "stop")
+@patch.object(CatchOutput, "start")
+def test_run_forced_fail_test_falls_back_to_the_whole_suite_when_the_probe_passes(_start, _stop, _dump_output, capfd):
+    runner = _mocked_runner_run_forced_failed(side_effect=[0, 1])
+
+    run_forced_fail_test(runner, tests=["tests/test_a.py::test_probe"])
+
+    assert runner.run_forced_fail.call_args_list == [call(tests=["tests/test_a.py::test_probe"]), call(tests=())]
+    out, _ = capfd.readouterr()
+    assert "done" in out
+
+
+# Negate the effects of CatchOutput because it does not play nicely with capfd in GitHub Actions
+@patch.object(CatchOutput, "dump_output")
+@patch.object(CatchOutput, "stop")
+@patch.object(CatchOutput, "start")
+def test_run_forced_fail_test_fails_when_the_probe_and_the_whole_suite_pass(_start, _stop, _dump_output, capfd):
+    runner = _mocked_runner_run_forced_failed(return_value=0)
+
+    with pytest.raises(SystemExit):
+        run_forced_fail_test(runner, tests=["tests/test_a.py::test_probe"])
+
+    assert runner.run_forced_fail.call_count == 2
 
 
 def test_do_not_mutate_top_level_decorators():

--- a/tests/test_test_scoping.py
+++ b/tests/test_test_scoping.py
@@ -1,0 +1,117 @@
+"""Scoping the clean and forced-fail runs to the mutants that will be tested."""
+
+from unittest.mock import Mock
+
+import pytest
+
+import mutmut.__main__
+from mutmut.__main__ import clean_run_test_selection
+from mutmut.__main__ import collect_or_load_stats
+from mutmut.__main__ import probe_tests_for_forced_fail
+from mutmut.__main__ import tests_for_mutants as relevant_tests_for
+from mutmut.runners.harness import ListAllTestsResult
+from mutmut.state import reset_state
+from mutmut.state import state
+
+
+@pytest.fixture(autouse=True)
+def _fresh_state():
+    reset_state()
+    yield
+    reset_state()
+
+
+def _associate(function: str, *tests: str, duration: float = 0.01) -> None:
+    for test in tests:
+        state().tests_by_mangled_function_name[function].add(test)
+        state().duration_by_test.setdefault(test, duration)
+
+
+class TestTestsForMutants:
+    def test_unions_the_tests_of_the_mutants_functions(self):
+        _associate("pkg.mod.x_f", "tests/test_a.py::test_one", "tests/test_a.py::test_two")
+        _associate("pkg.mod.x_g", "tests/test_b.py::test_three")
+        mutants = [
+            (None, "pkg.mod.x_f__mutmut_1", None),
+            (None, "pkg.mod.x_f__mutmut_2", None),
+            (None, "pkg.mod.x_g__mutmut_1", None),
+        ]
+
+        assert relevant_tests_for(mutants) == {  # type: ignore[arg-type]
+            "tests/test_a.py::test_one",
+            "tests/test_a.py::test_two",
+            "tests/test_b.py::test_three",
+        }
+
+    def test_mutants_in_a_package_init_are_looked_up_by_the_package_name(self):
+        _associate("pkg.x_f", "tests/test_a.py::test_one")
+
+        assert relevant_tests_for([(None, "pkg.__init__.x_f__mutmut_1", None)]) == {"tests/test_a.py::test_one"}  # type: ignore[list-item]
+
+    def test_unknown_functions_have_no_tests(self):
+        assert relevant_tests_for([(None, "pkg.mod.x_unknown__mutmut_1", None)]) == set()  # type: ignore[list-item]
+
+
+class TestCleanRunTestSelection:
+    def test_lists_the_relevant_tests_when_they_are_a_minority(self):
+        for i in range(10):
+            state().duration_by_test[f"tests/test_a.py::test_{i}"] = 0.01
+
+        assert clean_run_test_selection({"tests/test_a.py::test_3", "tests/test_a.py::test_1"}) == [
+            "tests/test_a.py::test_1",
+            "tests/test_a.py::test_3",
+        ]
+
+    def test_runs_the_configured_selection_once_most_tests_are_relevant(self):
+        for i in range(10):
+            state().duration_by_test[f"tests/test_a.py::test_{i}"] = 0.01
+
+        assert clean_run_test_selection({f"tests/test_a.py::test_{i}" for i in range(5)}) == []
+
+
+class TestProbeTestsForForcedFail:
+    def test_prefers_tests_that_reach_many_functions_from_different_files(self):
+        _associate(
+            "pkg.mod.x_a", "tests/test_a.py::test_broad", "tests/test_a.py::test_narrow", "tests/test_b.py::test_b"
+        )
+        _associate("pkg.mod.x_b", "tests/test_a.py::test_broad", "tests/test_b.py::test_b")
+        _associate("pkg.mod.x_c", "tests/test_a.py::test_broad")
+        _associate("pkg.mod.x_d", "tests/test_c.py::test_c")
+        tests = relevant_tests_for(
+            [(None, f"pkg.mod.x_{f}__mutmut_1", None) for f in "abcd"]  # type: ignore[misc]
+        )
+
+        assert probe_tests_for_forced_fail(tests) == [
+            "tests/test_a.py::test_broad",
+            "tests/test_b.py::test_b",
+            "tests/test_c.py::test_c",
+        ]
+
+    def test_is_limited_to_a_few_probes(self):
+        for i in range(6):
+            _associate("pkg.mod.x_a", f"tests/test_{i}.py::test")
+
+        assert len(probe_tests_for_forced_fail(state().tests_by_mangled_function_name["pkg.mod.x_a"], limit=3)) == 3
+
+    def test_means_everything_when_no_test_has_stats(self):
+        assert probe_tests_for_forced_fail({"tests/test_a.py::test_unknown"}) == []
+
+
+class TestCollectOrLoadStats:
+    def test_reports_a_full_collection(self, monkeypatch):
+        monkeypatch.setattr(mutmut.__main__, "load_stats", lambda: False)
+        monkeypatch.setattr(mutmut.__main__, "_refresh_change_detection_baseline", lambda: None)
+        collected = Mock()
+        monkeypatch.setattr(mutmut.__main__, "run_stats_collection", collected)
+
+        assert collect_or_load_stats(Mock()) is True
+        collected.assert_called_once()
+
+    def test_reports_loaded_stats(self, monkeypatch):
+        monkeypatch.setattr(mutmut.__main__, "load_stats", lambda: True)
+        monkeypatch.setattr(mutmut.__main__, "save_stats", lambda: None)
+        state().duration_by_test["tests/test_a.py::test_one"] = 0.01
+        runner = Mock()
+        runner.list_all_tests.return_value = ListAllTestsResult(ids={"tests/test_a.py::test_one"})
+
+        assert collect_or_load_stats(runner) is False


### PR DESCRIPTION
Skip the clean run when the suite is already known to pass, either because stats collection just ran every test or because nothing is left to test, and otherwise run only the tests the pending mutants use.

The clean test run executed the whole suite on every run, even right after a full stats collection had just run every test unmutated, and even when every mutant already had a verdict. The forced-fail check collected the whole suite to make one test fail.

1. The clean run is skipped when nothing needs it. Right after a full stats collection, which ran every test unmutated and stops on a failure, and when no mutant without a verdict has tests. Each skip is printed with its reason. collect_or_load_stats now returns whether a full collection ran.

2. Otherwise the clean run covers only the relevant tests. tests_for_mutants unions the tests stats collection associated with the mutants about to be tested (those without a verdict, or the ones named explicitly).

3. Listed test ids give way to the configured selection once they are a majority. Collecting many ids is slower than collecting the configured selection, so clean_run_test_selection returns the whole selection when the relevant tests are at least half of the known tests.

4. The forced-fail check probes a few tests. probe_tests_for_forced_fail ranks tests by how many mutated functions they reached during stats collection, since a test with a single association may only be linked through an import-time hit and pass, takes up to eight from different files (pytest stops at the first failure), and falls back to the whole suite if they unexpectedly pass.

5. TestRunner.run_forced_fail takes the tests to run, for both runners.