### PR TITLE
Parallel type checking when using mypy

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ~~~~~~~~~~
 
+* Performance: mypy (2.x) supports parallel type checks. Use one process fewer than ``--max-children``, leaving one for mutmut's own activity
+
 * Fix ``# pragma: no mutate block`` being silently ignored when placed on an ``else``, ``except``, ``except*`` or ``finally`` header, and on the ``try`` line of a ``try``/``except*``
 
 * Fix mutants being reported as survived when a test uses ``patch.dict(os.environ, ..., clear=True)`` (`#511`)

--- a/README.rst
+++ b/README.rst
@@ -198,6 +198,9 @@ To enable this filtering, configure the `type_check_command` to output json resu
     # for mypy
     type_check_command = ['mypy', 'your_source_dir', '--output', 'json', '--disable-error-code', 'unused-ignore']
 
+mypy 2 is asked to check with one worker process fewer than ``--max-children``. An explicit
+``--num-workers`` in the command, or ``MYPY_NUM_WORKERS`` in the environment, takes precedence.
+
 Currently, only `pyrefly` and `mypy` are supported.
 With `pyright` and `ty`, mutating a class method `Foo.bar()` can break the types of all methods of `Foo`,
 and therefore mutmut cannot match the type error with the mutant that caused the type error.

--- a/src/mutmut/__main__.py
+++ b/src/mutmut/__main__.py
@@ -1000,7 +1000,8 @@ def _run(mutant_names: tuple[str, ...] | list[str], max_children: int | None) ->
     mutants_caught_by_type_checker: dict[str, FailedTypeCheckMutant] = {}
     if config().type_check_command:
         with CatchOutput(spinner_title="Filtering mutations with type checker"):
-            mutants_caught_by_type_checker = filter_mutants_with_type_checker()
+            # leave a core for the test process that may run alongside the type checker
+            mutants_caught_by_type_checker = filter_mutants_with_type_checker(workers=max(max_children - 1, 1))
 
     # TODO: config/option for runner
     # runner = HammettRunner()

--- a/src/mutmut/mutation/file_mutation.py
+++ b/src/mutmut/mutation/file_mutation.py
@@ -653,9 +653,9 @@ def group_by_path(errors: list[TypeCheckingError]) -> dict[Path, list[TypeChecki
     return grouped
 
 
-def filter_mutants_with_type_checker() -> dict[str, FailedTypeCheckMutant]:
+def filter_mutants_with_type_checker(workers: int = 1) -> dict[str, FailedTypeCheckMutant]:
     with change_cwd(Path("mutants")):
-        errors = run_type_checker(config().type_check_command)
+        errors = run_type_checker(config().type_check_command, workers=workers)
         errors_by_path = group_by_path(errors)
 
         mutants_to_skip: dict[str, FailedTypeCheckMutant] = {}

--- a/src/mutmut/type_checking.py
+++ b/src/mutmut/type_checking.py
@@ -1,4 +1,5 @@
 import json
+import os
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -14,10 +15,24 @@ class TypeCheckingError:
     error_description: str
 
 
-def run_type_checker(type_check_command: list[str]) -> list[TypeCheckingError]:
+def type_checker_environment(type_check_command: list[str], workers: int) -> dict[str, str] | None:
+    """Return an environment with MYPY_NUM_WORKERS set, or None if the user already set a worker count."""
+    if workers <= 1 or "mypy" not in type_check_command or "MYPY_NUM_WORKERS" in os.environ:
+        return None
+    if any(arg == "-n" or arg.startswith(("--num-workers", "-n=")) for arg in type_check_command):
+        return None
+    return {**os.environ, "MYPY_NUM_WORKERS": str(workers)}
+
+
+def run_type_checker(type_check_command: list[str], workers: int = 1) -> list[TypeCheckingError]:
     errors = []
 
-    completed_process = subprocess.run(type_check_command, capture_output=True, encoding="utf-8")
+    completed_process = subprocess.run(
+        type_check_command,
+        capture_output=True,
+        encoding="utf-8",
+        env=type_checker_environment(type_check_command, workers),
+    )
 
     try:
         if "mypy" in type_check_command:

--- a/tests/test_type_checking.py
+++ b/tests/test_type_checking.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -7,6 +8,8 @@ from mutmut.mutation.file_mutation import filter_mutants_with_type_checker
 from mutmut.type_checking import TypeCheckingError
 from mutmut.type_checking import parse_mypy_report
 from mutmut.type_checking import parse_pyrefly_report
+from mutmut.type_checking import run_type_checker
+from mutmut.type_checking import type_checker_environment
 
 
 def test_mypy_parsing():
@@ -120,7 +123,7 @@ def test_filter_mutants_ignores_type_errors_in_files_without_mutants(tmp_path, m
     )
 
     monkeypatch.chdir(project)
-    monkeypatch.setattr("mutmut.mutation.file_mutation.run_type_checker", lambda command: [error])
+    monkeypatch.setattr("mutmut.mutation.file_mutation.run_type_checker", lambda command, workers: [error])
 
     assert filter_mutants_with_type_checker() == {}
 
@@ -145,7 +148,7 @@ def test_filter_mutants_still_raises_for_unowned_errors_in_mutated_files(tmp_pat
     )
 
     monkeypatch.chdir(project)
-    monkeypatch.setattr("mutmut.mutation.file_mutation.run_type_checker", lambda command: [error])
+    monkeypatch.setattr("mutmut.mutation.file_mutation.run_type_checker", lambda command, workers: [error])
 
     with pytest.raises(Exception, match="Could not find mutant for type error"):
         filter_mutants_with_type_checker()
@@ -158,3 +161,45 @@ def _make_pahts_relative(errors: list[TypeCheckingError]):
         assert cwd in error.file_path.parents
         # then convert it to relative path, so it's easy to use snapshot(...)
         error.file_path = error.file_path.relative_to(cwd)
+
+
+def test_run_type_checker_passes_the_workers_to_mypy(monkeypatch):
+    monkeypatch.delenv("MYPY_NUM_WORKERS", raising=False)
+    seen = {}
+
+    def fake_run(command, **kwargs):
+        seen["env"] = kwargs["env"]
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    run_type_checker(["mypy", "src", "--output", "json"], workers=4)
+
+    assert seen["env"]["MYPY_NUM_WORKERS"] == "4"
+
+
+class TestTypeCheckerEnvironment:
+    def test_asks_mypy_for_the_given_workers(self, monkeypatch):
+        monkeypatch.delenv("MYPY_NUM_WORKERS", raising=False)
+        monkeypatch.setenv("KEEP", "me")
+
+        env = type_checker_environment(["mypy", "src", "--output", "json"], workers=8)
+
+        assert env is not None
+        assert env["MYPY_NUM_WORKERS"] == "8"
+        assert env["KEEP"] == "me"
+
+    def test_leaves_the_environment_alone_by_default_and_for_other_checkers(self, monkeypatch):
+        monkeypatch.delenv("MYPY_NUM_WORKERS", raising=False)
+
+        assert type_checker_environment(["mypy", "src"], workers=1) is None
+        assert type_checker_environment(["pyrefly", "check", "--output-format=json"], workers=8) is None
+
+    @pytest.mark.parametrize("command", [["mypy", "-n", "2", "src"], ["mypy", "--num-workers=2", "src"]])
+    def test_an_explicit_worker_count_in_the_command_wins(self, monkeypatch, command):
+        monkeypatch.delenv("MYPY_NUM_WORKERS", raising=False)
+        assert type_checker_environment(command, workers=8) is None
+
+    def test_an_existing_environment_variable_wins(self, monkeypatch):
+        monkeypatch.setenv("MYPY_NUM_WORKERS", "3")
+        assert type_checker_environment(["mypy", "src"], workers=8) is None


### PR DESCRIPTION
Testing with --max-children 8 and python 2.x saw the type checking step run about 4x faster.

---

Mypy 2 supports parallel type checking by reading MYPY_NUM_WORKERS; older versions ignore it. This change sets workers to --max-children minus one; which leaves a slot open for mutmut to do work in parallel.